### PR TITLE
Update ci recipes and timeout feedback

### DIFF
--- a/playwright/custom-environment.js
+++ b/playwright/custom-environment.js
@@ -94,7 +94,7 @@ class CustomEnvironment extends PlaywrightEnvironment {
           try {
             await __waitForElement('#root');
           } catch(err) {
-            const message = \`Timed out waiting for Storybook to load after 10 seconds. Are you sure the Storybook is running correctly in that URL?\n\n\nHTML: \${document.body.innerHTML}\`;
+            const message = \`Timed out waiting for Storybook to load after 10 seconds. Are you sure the Storybook is running correctly in that URL? Is the Storybook private (e.g. under authentication layers)?\n\n\nHTML: \${document.body.innerHTML}\`;
             throw new StorybookTestRunnerError(storyId, hasPlayFn, message);
           }
 


### PR DESCRIPTION
In order to avoid users getting into frustrating situations like running test-runner against a private Storybook, I updated the docs and the feedback message when it times out in situations like that.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.2-canary.27.eabf5e0.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.0.2-canary.27.eabf5e0.0
  # or 
  yarn add @storybook/test-runner@0.0.2-canary.27.eabf5e0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
