### PR TITLE
feat: add update snapshot command to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Usage: test-storybook [options]
 | `--no-cache`                    | Disable the cache <br/>`test-storybook --no-cache`                                                                        |
 | `--clearCache`                  | Deletes the Jest cache directory and then exits without running tests <br/>`test-storybook --clearCache`                  |
 | `--verbose`                     | Display individual test results with the test suite hierarchy <br/>`test-storybook --verbose`                             |
+| `-u`, `--updateSnapshot`        | Use this flag to re-record every snapshot that fails during this test run <br/>`test-storybook -u`                        |
 
 ## Configuration
 

--- a/src/util/getParsedCliOptions.ts
+++ b/src/util/getParsedCliOptions.ts
@@ -11,7 +11,11 @@ export const getParsedCliOptions = () => {
     )
     .option('--no-cache', 'Disable the cache')
     .option('--clearCache', 'Deletes the Jest cache directory and then exits without running tests')
-    .option('--verbose', 'Display individual test results with the test suite hierarchy');
+    .option('--verbose', 'Display individual test results with the test suite hierarchy')
+    .option(
+      '-u, --updateSnapshot',
+      'Use this flag to re-record every snapshot that fails during this test run'
+    );
 
   program.exitOverride();
 


### PR DESCRIPTION
In case people are using test hooks for snapshot testing, it's important to expose this jest flag to update the snapshots without having to go into watch mode
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.3-canary.52.ec4fcc0.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.0.3-canary.52.ec4fcc0.0
  # or 
  yarn add @storybook/test-runner@0.0.3-canary.52.ec4fcc0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
