### PR TITLE
feat: add eject command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,33 +113,15 @@ Usage: test-storybook [options]
 | `--clearCache`                  | Deletes the Jest cache directory and then exits without running tests <br/>`test-storybook --clearCache`                  |
 | `--verbose`                     | Display individual test results with the test suite hierarchy <br/>`test-storybook --verbose`                             |
 | `-u`, `--updateSnapshot`        | Use this flag to re-record every snapshot that fails during this test run <br/>`test-storybook -u`                        |
+| `--eject`                       | Creates a local configuration file to override defaults of the test-runner <br/>`test-storybook --eject`                  |
 
 ## Configuration
 
 The test runner is based on [Jest](https://jestjs.io/) and will accept the [CLI options](https://jestjs.io/docs/cli) that Jest does, like `--watch`, `--maxWorkers`, etc.
 
-The test runner works out of the box, but you can override its Jest configuration by adding a `test-runner-jest.config.js` that sets up your environment in the root folder of your project.
+The test runner works out of the box, but if you want better control over its configuration, you can run `test-storybook --eject` to create a local `test-runner-jest.config.js` file in the root folder of your project, which will be used by the test runner.
 
-```js
-// test-runner-jest.config.js
-module.exports = {
-  cacheDirectory: 'node_modules/.cache/storybook/test-runner',
-  testMatch: ['**/*.stories.[jt]s(x)?'],
-  transform: {
-    '^.+\\.stories\\.[jt]sx?$': '@storybook/test-runner/playwright/transform',
-    '^.+\\.[jt]sx?$': 'babel-jest',
-  },
-  preset: 'jest-playwright-preset',
-  testEnvironment: '@storybook/test-runner/playwright/custom-environment.js',
-  testEnvironmentOptions: {
-    'jest-playwright': {
-      browsers: ['chromium', 'firefox', 'webkit'], // run tests against all browsers
-    },
-  },
-};
-```
-
-The runner uses [jest-playwright](https://github.com/playwright-community/jest-playwright) and you can pass [testEnvironmentOptions](https://github.com/playwright-community/jest-playwright#configuration) to further configure it, such as how it's done above to run tests against all browsers instead of just chromium.
+The test runner uses [jest-playwright](https://github.com/playwright-community/jest-playwright) and you can pass [testEnvironmentOptions](https://github.com/playwright-community/jest-playwright#configuration) to further configure it, such as how it's done above to run tests against all browsers instead of just chromium. For this you must eject the test runner configuration.
 
 ## Running against a deployed Storybook
 

--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -114,7 +114,7 @@ function ejectConfiguration () {
   const fileAlreadyExists = fs.existsSync(destination)
   
   if(fileAlreadyExists) {
-    console.log('[test-runner] Found existing file, overriding...')
+    throw new Error('Found existing file. Please delete it and rerun this command')
   }
   
   fs.copyFileSync(origin, destination)

--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -108,11 +108,29 @@ async function fetchStoriesJson(url) {
   return tmpDir;
 }
 
+function ejectConfiguration () {
+  const origin = path.resolve(__dirname, '../playwright/test-runner-jest.config.js')
+  const destination = path.resolve('test-runner-jest.config.js')
+  const fileAlreadyExists = fs.existsSync(destination)
+  
+  if(fileAlreadyExists) {
+    console.log('[test-runner] Found existing file, overriding...')
+  }
+  
+  fs.copyFileSync(origin, destination)
+  console.log('[test-runner] Configuration file successfully copied as test-runner-jest.config.js')
+}
+
 const main = async () => {
+  const { jestOptions, runnerOptions } = getCliOptions();
+
+  if(runnerOptions.eject) {
+    ejectConfiguration();
+    process.exit(0);
+  }
+
   const targetURL = sanitizeURL(process.env.TARGET_URL || `http://localhost:6006`);
   await checkStorybook(targetURL);
-
-  const { jestOptions, runnerOptions } = getCliOptions()
 
   if (runnerOptions.storiesJson) {
     storiesJsonTmpDir = await fetchStoriesJson(targetURL);

--- a/src/util/getCliOptions.ts
+++ b/src/util/getCliOptions.ts
@@ -4,13 +4,14 @@ type CliOptions = {
   runnerOptions: {
     storiesJson: boolean;
     configDir: string;
+    eject?: boolean;
   };
   jestOptions: string[];
 };
 
 type StorybookRunnerCommand = keyof CliOptions['runnerOptions'];
 
-const STORYBOOK_RUNNER_COMMANDS: StorybookRunnerCommand[] = ['storiesJson', 'configDir'];
+const STORYBOOK_RUNNER_COMMANDS: StorybookRunnerCommand[] = ['storiesJson', 'configDir', 'eject'];
 
 export const defaultRunnerOptions: CliOptions['runnerOptions'] = {
   configDir: '.storybook',

--- a/src/util/getParsedCliOptions.ts
+++ b/src/util/getParsedCliOptions.ts
@@ -15,6 +15,10 @@ export const getParsedCliOptions = () => {
     .option(
       '-u, --updateSnapshot',
       'Use this flag to re-record every snapshot that fails during this test run'
+    )
+    .option(
+      '--eject',
+      'Creates a local configuration file to override defaults of the test-runner. Use it only if you want to have better control over the runner configurations'
     );
 
   program.exitOverride();

--- a/test-runner-jest.config.js
+++ b/test-runner-jest.config.js
@@ -1,5 +1,5 @@
 // !!! This file is used as an override to the test-runner configuration for this repo only !!!
-// If you want to create your own override for your project, use playwright/test-runner-jest.config.js as base instead
+// If you want to create your own override for your project, run test-storybook eject instead
 
 const { getJestConfig } = require('./dist/cjs');
 


### PR DESCRIPTION
Issue: #42 

Running eject for the first time:
![image](https://user-images.githubusercontent.com/1671563/154281338-a55cd509-33c2-489f-bac4-2f24813f4f78.png)

And in case the config file already exists, it will notify the user (but still override it without prompting)
![image](https://user-images.githubusercontent.com/1671563/154281379-7cdca169-8696-4597-8d94-fc713765b967.png)

### Improvement points/challenges for later

- Using the test-runner in monorepos. Very likely the logic to detect and use the config file is not ready for that
- Adding inquirer or any other library to allow for prompting user to things like (are you sure you want to override ; we detected an external storybook url, do you want to use stories-json flag)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.3-canary.54.04b73e7.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.0.3-canary.54.04b73e7.0
  # or 
  yarn add @storybook/test-runner@0.0.3-canary.54.04b73e7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
