### PR TITLE
feat: add browsers flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,19 +100,19 @@ yarn test-storybook
 Usage: test-storybook [options]
 ```
 
-| Options                         | Description                                                                                                               |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `--help`                        | Output usage information <br/>`test-storybook --help`                                                                     |
-| `-s`, `--stories-json`          | Run in stories json mode (requires a compatible Storybook) <br/>`test-storybook --stories-json`                           |
-| `-c`, `--config-dir [dir-name]` | Directory where to load Storybook configurations from <br/>`test-storybook -c .storybook`                                 |
-| `--watch`                       | Run in watch mode <br/>`test-storybook --watch`                                                                           |
-| `--browsers`                    | Define browsers to run tests in. One or multiple of: chromium, firefox, webkit <br/>`test-storybook --browsers firefox`   |
-| `--maxWorkers [amount]`         | Specifies the maximum number of workers the worker-pool will spawn for running tests <br/>`test-storybook --maxWorkers=2` |
-| `--no-cache`                    | Disable the cache <br/>`test-storybook --no-cache`                                                                        |
-| `--clearCache`                  | Deletes the Jest cache directory and then exits without running tests <br/>`test-storybook --clearCache`                  |
-| `--verbose`                     | Display individual test results with the test suite hierarchy <br/>`test-storybook --verbose`                             |
-| `-u`, `--updateSnapshot`        | Use this flag to re-record every snapshot that fails during this test run <br/>`test-storybook -u`                        |
-| `--eject`                       | Creates a local configuration file to override defaults of the test-runner <br/>`test-storybook --eject`                  |
+| Options                         | Description                                                                                                                      |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `--help`                        | Output usage information <br/>`test-storybook --help`                                                                            |
+| `-s`, `--stories-json`          | Run in stories json mode (requires a compatible Storybook) <br/>`test-storybook --stories-json`                                  |
+| `-c`, `--config-dir [dir-name]` | Directory where to load Storybook configurations from <br/>`test-storybook -c .storybook`                                        |
+| `--watch`                       | Run in watch mode <br/>`test-storybook --watch`                                                                                  |
+| `--browsers`                    | Define browsers to run tests in. One or multiple of: chromium, firefox, webkit <br/>`test-storybook --browsers firefox chromium` |
+| `--maxWorkers [amount]`         | Specifies the maximum number of workers the worker-pool will spawn for running tests <br/>`test-storybook --maxWorkers=2`        |
+| `--no-cache`                    | Disable the cache <br/>`test-storybook --no-cache`                                                                               |
+| `--clearCache`                  | Deletes the Jest cache directory and then exits without running tests <br/>`test-storybook --clearCache`                         |
+| `--verbose`                     | Display individual test results with the test suite hierarchy <br/>`test-storybook --verbose`                                    |
+| `-u`, `--updateSnapshot`        | Use this flag to re-record every snapshot that fails during this test run <br/>`test-storybook -u`                               |
+| `--eject`                       | Creates a local configuration file to override defaults of the test-runner <br/>`test-storybook --eject`                         |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Usage: test-storybook [options]
 | `-s`, `--stories-json`          | Run in stories json mode (requires a compatible Storybook) <br/>`test-storybook --stories-json`                           |
 | `-c`, `--config-dir [dir-name]` | Directory where to load Storybook configurations from <br/>`test-storybook -c .storybook`                                 |
 | `--watch`                       | Run in watch mode <br/>`test-storybook --watch`                                                                           |
+| `--browsers`                    | Define browsers to run tests in. One or multiple of: chromium, firefox, webkit <br/>`test-storybook --browsers firefox`   |
 | `--maxWorkers [amount]`         | Specifies the maximum number of workers the worker-pool will spawn for running tests <br/>`test-storybook --maxWorkers=2` |
 | `--no-cache`                    | Disable the cache <br/>`test-storybook --no-cache`                                                                        |
 | `--clearCache`                  | Deletes the Jest cache directory and then exits without running tests <br/>`test-storybook --clearCache`                  |

--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -132,6 +132,10 @@ const main = async () => {
   const targetURL = sanitizeURL(process.env.TARGET_URL || `http://localhost:6006`);
   await checkStorybook(targetURL);
 
+  if (runnerOptions.browsers) {
+    process.env.TEST_BROWSERS = runnerOptions.browsers.join(';');
+  }
+
   if (runnerOptions.storiesJson) {
     storiesJsonTmpDir = await fetchStoriesJson(targetURL);
     process.env.TEST_ROOT = storiesJsonTmpDir;

--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -132,8 +132,9 @@ const main = async () => {
   const targetURL = sanitizeURL(process.env.TARGET_URL || `http://localhost:6006`);
   await checkStorybook(targetURL);
 
-  if (runnerOptions.browsers) {
-    process.env.TEST_BROWSERS = runnerOptions.browsers.join(';');
+  // Use TEST_BROWSERS if set, otherwise get from --browser option
+  if (!process.env.TEST_BROWSERS && runnerOptions.browsers) {
+    process.env.TEST_BROWSERS = runnerOptions.browsers.join(',');
   }
 
   if (runnerOptions.storiesJson) {

--- a/src/config/jest-playwright.ts
+++ b/src/config/jest-playwright.ts
@@ -1,5 +1,5 @@
 export const getJestConfig = () => {
-  const { TEST_ROOT, TEST_MATCH, STORYBOOK_STORIES_PATTERN } = process.env;
+  const { TEST_ROOT, TEST_MATCH, STORYBOOK_STORIES_PATTERN, TEST_BROWSERS } = process.env;
 
   let config = {
     rootDir: process.cwd(),
@@ -14,6 +14,11 @@ export const getJestConfig = () => {
     globalTeardown: '@storybook/test-runner/playwright/global-teardown.js',
     testEnvironment: '@storybook/test-runner/playwright/custom-environment.js',
     setupFilesAfterEnv: ['@storybook/test-runner/playwright/jest-setup.js'],
+    testEnvironmentOptions: {
+      'jest-playwright': {
+        browsers: TEST_BROWSERS.split(';'),
+      },
+    },
   };
 
   if (TEST_MATCH) {

--- a/src/config/jest-playwright.ts
+++ b/src/config/jest-playwright.ts
@@ -16,7 +16,9 @@ export const getJestConfig = () => {
     setupFilesAfterEnv: ['@storybook/test-runner/playwright/jest-setup.js'],
     testEnvironmentOptions: {
       'jest-playwright': {
-        browsers: TEST_BROWSERS.split(';'),
+        browsers: TEST_BROWSERS.split(',')
+          .filter(Boolean)
+          .map((p) => p.trim().toLowerCase()),
       },
     },
   };

--- a/src/config/jest-playwright.ts
+++ b/src/config/jest-playwright.ts
@@ -17,8 +17,8 @@ export const getJestConfig = () => {
     testEnvironmentOptions: {
       'jest-playwright': {
         browsers: TEST_BROWSERS.split(',')
-          .filter(Boolean)
-          .map((p) => p.trim().toLowerCase()),
+          .map((p) => p.trim().toLowerCase())
+          .filter(Boolean),
       },
     },
   };

--- a/src/util/getCliOptions.test.ts
+++ b/src/util/getCliOptions.test.ts
@@ -1,12 +1,7 @@
-import { defaultRunnerOptions, getCliOptions } from './getCliOptions';
+import { getCliOptions } from './getCliOptions';
 import * as cliHelper from './getParsedCliOptions';
 
 describe('getCliOptions', () => {
-  it('returns default options if no extra option is passed', () => {
-    const opts = getCliOptions();
-    expect(opts.runnerOptions).toMatchObject(defaultRunnerOptions);
-  });
-
   it('returns custom options if passed', () => {
     const customConfig = { configDir: 'custom', storiesJson: true };
     jest

--- a/src/util/getCliOptions.ts
+++ b/src/util/getCliOptions.ts
@@ -1,21 +1,29 @@
 import { getParsedCliOptions } from './getParsedCliOptions';
+import type { BrowserType } from 'jest-playwright-preset';
 
 type CliOptions = {
   runnerOptions: {
     storiesJson: boolean;
     configDir: string;
     eject?: boolean;
+    browsers?: BrowserType | BrowserType[];
   };
   jestOptions: string[];
 };
 
 type StorybookRunnerCommand = keyof CliOptions['runnerOptions'];
 
-const STORYBOOK_RUNNER_COMMANDS: StorybookRunnerCommand[] = ['storiesJson', 'configDir', 'eject'];
+const STORYBOOK_RUNNER_COMMANDS: StorybookRunnerCommand[] = [
+  'storiesJson',
+  'configDir',
+  'browsers',
+  'eject',
+];
 
 export const defaultRunnerOptions: CliOptions['runnerOptions'] = {
   configDir: '.storybook',
   storiesJson: false,
+  browsers: ['chromium'],
 };
 
 export const getCliOptions = () => {

--- a/src/util/getCliOptions.ts
+++ b/src/util/getCliOptions.ts
@@ -3,8 +3,8 @@ import type { BrowserType } from 'jest-playwright-preset';
 
 type CliOptions = {
   runnerOptions: {
-    storiesJson: boolean;
-    configDir: string;
+    storiesJson?: boolean;
+    configDir?: string;
     eject?: boolean;
     browsers?: BrowserType | BrowserType[];
   };
@@ -20,17 +20,11 @@ const STORYBOOK_RUNNER_COMMANDS: StorybookRunnerCommand[] = [
   'eject',
 ];
 
-export const defaultRunnerOptions: CliOptions['runnerOptions'] = {
-  configDir: '.storybook',
-  storiesJson: false,
-  browsers: ['chromium'],
-};
-
 export const getCliOptions = () => {
   const { options: allOptions, extraArgs } = getParsedCliOptions();
 
   const defaultOptions: CliOptions = {
-    runnerOptions: { ...defaultRunnerOptions },
+    runnerOptions: {},
     jestOptions: process.argv.splice(0, 2),
   };
 

--- a/src/util/getParsedCliOptions.ts
+++ b/src/util/getParsedCliOptions.ts
@@ -6,6 +6,10 @@ export const getParsedCliOptions = () => {
     .option('-c, --config-dir <directory>', 'Directory where to load Storybook configurations from')
     .option('--watch', 'Run in watch mode')
     .option(
+      '--browsers <browsers...>',
+      'Define browsers to run tests in. Could be one or multiple of: chromium, firefox, webkit'
+    )
+    .option(
       '--maxWorkers <amount>',
       'Specifies the maximum number of workers the worker-pool will spawn for running tests'
     )

--- a/src/util/getParsedCliOptions.ts
+++ b/src/util/getParsedCliOptions.ts
@@ -2,12 +2,21 @@ export const getParsedCliOptions = () => {
   const { program } = require('commander');
 
   program
-    .option('-s, --stories-json', 'Run in stories json mode (requires a compatible Storybook)')
-    .option('-c, --config-dir <directory>', 'Directory where to load Storybook configurations from')
-    .option('--watch', 'Run in watch mode')
+    .option(
+      '-s, --stories-json',
+      'Run in stories json mode (requires a compatible Storybook)',
+      false
+    )
+    .option(
+      '-c, --config-dir <directory>',
+      'Directory where to load Storybook configurations from',
+      '.storybook'
+    )
+    .option('--watch', 'Run in watch mode', false)
     .option(
       '--browsers <browsers...>',
-      'Define browsers to run tests in. Could be one or multiple of: chromium, firefox, webkit'
+      'Define browsers to run tests in. Could be one or multiple of: chromium, firefox, webkit',
+      ['chromium']
     )
     .option(
       '--maxWorkers <amount>',


### PR DESCRIPTION
This adds the possibility to set browsers via CLI such as:

```
yarn test-storybook --browsers webkit firefox
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.3-canary.55.c9e2fe2.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.0.3-canary.55.c9e2fe2.0
  # or 
  yarn add @storybook/test-runner@0.0.3-canary.55.c9e2fe2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
