### PR TITLE
feat: add url flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ yarn storybook
 yarn test-storybook
 ```
 
-> **NOTE:** The runner assumes that your Storybook is running on port `6006`. If you're running Storybook in another port, set the TARGET_URL before running your command like:
+> **NOTE:** The runner assumes that your Storybook is running on port `6006`. If you're running Storybook in another port, either use --url or set the TARGET_URL before running your command like:
 >
 > ```jsx
+> yarn test-storybook --url http://localhost:9009
+> or
 > TARGET_URL=http://localhost:9009 yarn test-storybook
 > ```
 
@@ -106,6 +108,7 @@ Usage: test-storybook [options]
 | `-s`, `--stories-json`          | Run in stories json mode (requires a compatible Storybook) <br/>`test-storybook --stories-json`                                  |
 | `-c`, `--config-dir [dir-name]` | Directory where to load Storybook configurations from <br/>`test-storybook -c .storybook`                                        |
 | `--watch`                       | Run in watch mode <br/>`test-storybook --watch`                                                                                  |
+| `--url`                         | Define the URL to run tests in. Useful for custom Storybook URLs <br/>`test-storybook --url http://the-storybook-url-here.com`   |
 | `--browsers`                    | Define browsers to run tests in. One or multiple of: chromium, firefox, webkit <br/>`test-storybook --browsers firefox chromium` |
 | `--maxWorkers [amount]`         | Specifies the maximum number of workers the worker-pool will spawn for running tests <br/>`test-storybook --maxWorkers=2`        |
 | `--no-cache`                    | Disable the cache <br/>`test-storybook --no-cache`                                                                               |
@@ -124,11 +127,17 @@ The test runner uses [jest-playwright](https://github.com/playwright-community/j
 
 ## Running against a deployed Storybook
 
-By default, the test runner assumes that you're running it against a locally served Storybook.
+By default, the test runner assumes that you're running it against a locally served Storybook on port 6006.
 If you want to define a target url so it runs against deployed Storybooks, you can do so by passing the `TARGET_URL` environment variable:
 
 ```bash
 TARGET_URL=https://the-storybook-url-here.com yarn test-storybook
+```
+
+Or by using the `--url` flag:
+
+```bash
+yarn test-storybook --url https://the-storybook-url-here.com
 ```
 
 ### Stories.json mode

--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -74,9 +74,9 @@ async function checkStorybook(url) {
     console.error(
       dedent`[test-storybook] It seems that your Storybook instance is not running at: ${url}. Are you sure it's running?
       
-      If you're not running Storybook on the default 6006 port or want to run the tests against any custom URL, you can set the TARGET_URL variable like so:
+      If you're not running Storybook on the default 6006 port or want to run the tests against any custom URL, you can pass the --url flag like so:
       
-      TARGET_URL=http://localhost:9009 yarn test-storybook
+      yarn test-storybook --url http://localhost:9009
       
       More info at https://github.com/storybookjs/test-runner#getting-started`
     );
@@ -129,8 +129,14 @@ const main = async () => {
     process.exit(0);
   }
 
-  const targetURL = sanitizeURL(process.env.TARGET_URL || `http://localhost:6006`);
+  const targetURL = sanitizeURL(process.env.TARGET_URL || runnerOptions.url);
   await checkStorybook(targetURL);
+  
+  process.env.TARGET_URL = targetURL;
+  
+  if(process.env.REFERENCE_URL) {
+    process.env.REFERENCE_URL = sanitizeURL(process.env.REFERENCE_URL);
+  }
 
   // Use TEST_BROWSERS if set, otherwise get from --browser option
   if (!process.env.TEST_BROWSERS && runnerOptions.browsers) {

--- a/src/util/getCliOptions.ts
+++ b/src/util/getCliOptions.ts
@@ -4,6 +4,7 @@ import type { BrowserType } from 'jest-playwright-preset';
 type CliOptions = {
   runnerOptions: {
     storiesJson?: boolean;
+    url?: string;
     configDir?: string;
     eject?: boolean;
     browsers?: BrowserType | BrowserType[];
@@ -18,6 +19,7 @@ const STORYBOOK_RUNNER_COMMANDS: StorybookRunnerCommand[] = [
   'configDir',
   'browsers',
   'eject',
+  'url',
 ];
 
 export const getCliOptions = () => {

--- a/src/util/getParsedCliOptions.ts
+++ b/src/util/getParsedCliOptions.ts
@@ -19,6 +19,11 @@ export const getParsedCliOptions = () => {
       ['chromium']
     )
     .option(
+      '--url <url>',
+      'Define the URL to run tests in. Useful for custom Storybook URLs',
+      'http://localhost:6006'
+    )
+    .option(
       '--maxWorkers <amount>',
       'Specifies the maximum number of workers the worker-pool will spawn for running tests'
     )


### PR DESCRIPTION
This PR adds a new way to set target url by using `--url` instead of `process.env.TARGET_URL`.

If the user does use TARGET_URL, it will be taken as precedence so it supports both.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.3-canary.56.6df6b2d.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.0.3-canary.56.6df6b2d.0
  # or 
  yarn add @storybook/test-runner@0.0.3-canary.56.6df6b2d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
