### PR TITLE
fix: use correct import in generated test

### DIFF
--- a/src/playwright/transformPlaywright.test.ts
+++ b/src/playwright/transformPlaywright.test.ts
@@ -51,7 +51,7 @@ describe('Playwright', () => {
 
       const {
         setupPage
-      } = require('../../dist/cjs');
+      } = require('@storybook/test-runner');
 
       if (!require.main) {
         describe("foo/bar", () => {
@@ -122,7 +122,7 @@ describe('Playwright', () => {
 
       const {
         setupPage
-      } = require('../../dist/cjs');
+      } = require('@storybook/test-runner');
 
       if (!require.main) {
         describe("foo/bar", () => {
@@ -194,7 +194,7 @@ describe('Playwright', () => {
 
       const {
         setupPage
-      } = require('../../dist/cjs');
+      } = require('@storybook/test-runner');
 
       if (!require.main) {
         describe("Example/Header", () => {

--- a/src/playwright/transformPlaywright.ts
+++ b/src/playwright/transformPlaywright.ts
@@ -7,7 +7,7 @@ import { transformCsf } from '../csf/transformCsf';
 
 const filePrefixer = template(`
   import global from 'global';
-  const { setupPage } = require('../../dist/cjs');
+  const { setupPage } = require('@storybook/test-runner');
 `);
 
 export const testPrefixer = template(

--- a/test-runner-jest.config.js
+++ b/test-runner-jest.config.js
@@ -14,4 +14,8 @@ module.exports = {
   globalTeardown: './playwright/global-teardown.js',
   testEnvironment: './playwright/custom-environment.js',
   setupFilesAfterEnv: ['./playwright/jest-setup.js'],
+  // use local build when the package is referred
+  moduleNameMapper: {
+    '@storybook/test-runner': '<rootDir>/dist/cjs/index.js'
+  },
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.4-canary.65.73bc8bf.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.0.4-canary.65.73bc8bf.0
  # or 
  yarn add @storybook/test-runner@0.0.4-canary.65.73bc8bf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
