### PR TITLE
Add option to only run play or smoke tests

### DIFF
--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -137,6 +137,10 @@ const main = async () => {
     process.exit(0);
   }
 
+  if (runnerOptions.onlyType) {
+    process.env.ONLY_TYPE = runnerOptions.onlyType;
+  }
+
   const targetURL = sanitizeURL(process.env.TARGET_URL || runnerOptions.url);
   await checkStorybook(targetURL);
 

--- a/src/playwright/transformPlaywright.test.ts
+++ b/src/playwright/transformPlaywright.test.ts
@@ -251,4 +251,154 @@ describe('Playwright', () => {
       }
     `);
   });
+
+  it('should only generate specified test type when ONLY_TYPE option is set', () => {
+    process.env.ONLY_TYPE = 'play'
+
+    expect(
+      transformPlaywright(
+        dedent`
+        export default { title: 'foo/bar', component: Button };
+        export const A = () => {};
+        A.play = () => {};
+        export const B = () => {};
+      `,
+        filename
+      )
+    ).toMatchInlineSnapshot(`
+      import global from 'global';
+
+      const {
+        setupPage
+      } = require('@storybook/test-runner');
+
+      if (!require.main) {
+        describe("foo/bar", () => {
+        describe("A", () => {
+          it("play-test", async () => {
+            const testFn = async () => {
+              const context = {
+                id: "foo-bar--a",
+                title: "foo/bar",
+                name: "A"
+              };
+              page.on('pageerror', err => {
+                page.evaluate(({
+                  id,
+                  err
+                }) => __throwError(id, err), {
+                  id: "foo-bar--a",
+                  err: err.message
+                });
+              });
+
+              if (global.__sbPreRender) {
+                await global.__sbPreRender(page, context);
+              }
+
+              const result = await page.evaluate(({
+                id,
+                hasPlayFn
+              }) => __test(id, hasPlayFn), {
+                id: "foo-bar--a"
+              });
+
+              if (global.__sbPostRender) {
+                await global.__sbPostRender(page, context);
+              }
+
+              return result;
+            };
+
+            try {
+              await testFn();
+            } catch (err) {
+              if (err.toString().includes('Execution context was destroyed')) {
+                await jestPlaywright.resetPage();
+                await setupPage(global.page);
+                await testFn();
+              } else {
+                throw err;
+              }
+            }
+          });
+        });
+      });
+      }
+    `);
+
+    process.env.ONLY_TYPE = 'smoke'
+
+    expect(
+      transformPlaywright(
+        dedent`
+        export default { title: 'foo/bar', component: Button };
+        export const A = () => {};
+        A.play = () => {};
+        export const B = () => {};
+      `,
+        filename
+      )
+    ).toMatchInlineSnapshot(`
+      import global from 'global';
+
+      const {
+        setupPage
+      } = require('@storybook/test-runner');
+
+      if (!require.main) {
+        describe("foo/bar", () => {
+        describe("B", () => {
+          it("smoke-test", async () => {
+            const testFn = async () => {
+              const context = {
+                id: "foo-bar--b",
+                title: "foo/bar",
+                name: "B"
+              };
+              page.on('pageerror', err => {
+                page.evaluate(({
+                  id,
+                  err
+                }) => __throwError(id, err), {
+                  id: "foo-bar--b",
+                  err: err.message
+                });
+              });
+
+              if (global.__sbPreRender) {
+                await global.__sbPreRender(page, context);
+              }
+
+              const result = await page.evaluate(({
+                id,
+                hasPlayFn
+              }) => __test(id, hasPlayFn), {
+                id: "foo-bar--b"
+              });
+
+              if (global.__sbPostRender) {
+                await global.__sbPostRender(page, context);
+              }
+
+              return result;
+            };
+
+            try {
+              await testFn();
+            } catch (err) {
+              if (err.toString().includes('Execution context was destroyed')) {
+                await jestPlaywright.resetPage();
+                await setupPage(global.page);
+                await testFn();
+              } else {
+                throw err;
+              }
+            }
+          });
+        });
+      });
+      }
+    `);
+  });
 });

--- a/src/playwright/transformPlaywright.ts
+++ b/src/playwright/transformPlaywright.ts
@@ -2,7 +2,7 @@ import { relative } from 'path';
 import template from '@babel/template';
 import { autoTitle } from '@storybook/store';
 
-import { getStorybookMetadata } from '../util';
+import { getStorybookMetadata, StorybookTestType } from '../util';
 import { transformCsf } from '../csf/transformCsf';
 
 const filePrefixer = template(`
@@ -70,6 +70,7 @@ export const transformPlaywright = (src: string, filename: string) => {
     insertTestIfEmpty: true,
     clearBody: true,
     defaultTitle,
+    onlyType: process.env.ONLY_TYPE as StorybookTestType,
   });
   return result;
 };

--- a/src/util/getCliOptions.ts
+++ b/src/util/getCliOptions.ts
@@ -1,6 +1,8 @@
 import { getParsedCliOptions } from './getParsedCliOptions';
 import type { BrowserType } from 'jest-playwright-preset';
 
+export type StorybookTestType = 'play' | 'smoke';
+
 type CliOptions = {
   runnerOptions: {
     storiesJson?: boolean;
@@ -8,6 +10,7 @@ type CliOptions = {
     configDir?: string;
     eject?: boolean;
     browsers?: BrowserType | BrowserType[];
+    onlyType?: StorybookTestType;
   };
   jestOptions: string[];
 };
@@ -19,6 +22,7 @@ const STORYBOOK_RUNNER_COMMANDS: StorybookRunnerCommand[] = [
   'configDir',
   'browsers',
   'eject',
+  'onlyType',
   'url',
 ];
 

--- a/src/util/getParsedCliOptions.ts
+++ b/src/util/getParsedCliOptions.ts
@@ -1,5 +1,5 @@
 export const getParsedCliOptions = () => {
-  const { program } = require('commander');
+  const { program, Option } = require('commander');
 
   program
     .option(
@@ -7,6 +7,12 @@ export const getParsedCliOptions = () => {
       'Run in stories json mode. Automatically detected (requires a compatible Storybook)'
     )
     .option('--no-stories-json', 'Disable stories json mode')
+    .addOption(
+      new Option(
+        '--only-type <testType>',
+        'Only run selected test type. Does not work with stories json mode.'
+      ).choices(['play', 'smoke'])
+    )
     .option(
       '-c, --config-dir <directory>',
       'Directory where to load Storybook configurations from',


### PR DESCRIPTION
## What I did
- Adds an option `--only-type <testType>` that takes either `play` or `smoke`
- If the option is set, only Play or only Smoke tests will run.
- I couldn't figure out how to do this for stories json mode and as far as I know, I don't think this type of information is available in the `stories.json`?
- Happy to change the option name, wasn't sure what to call it 😅

## How To Test
```
# Should only run play tests
yarn test-storybook --only-type play button
# Should only run smoke tests
yarn test-storybook --only-type smoke button
```

Closes #28 