### PR TITLE
cleanup page opened log

### DIFF
--- a/src/setup-page.ts
+++ b/src/setup-page.ts
@@ -18,7 +18,6 @@ const sanitizeURL = (url) => {
 };
 
 export const setupPage = async (page) => {
-  const start = new Date();
   const targetURL = sanitizeURL(process.env.TARGET_URL || `http://localhost:6006`);
   const viewMode = process.env.VIEW_MODE || 'story';
   const renderedEvent = viewMode === 'docs' ? 'docsRendered' : 'storyRendered';
@@ -39,7 +38,6 @@ export const setupPage = async (page) => {
 
     throw err;
   }); // FIXME: configure
-  console.log(`page loaded in ${new Date() - start}ms.`);
 
   // if we ever want to log something from the browser to node
   await page.exposeBinding('logToPage', (_, message) => console.log(message));


### PR DESCRIPTION
The  "page loaded in Xms" were adding noise to the reports:

![image](https://user-images.githubusercontent.com/1671563/162178702-41bc3242-788f-46ee-b14d-df817f8a38f7.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.5-canary.86.11580c1.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.0.5-canary.86.11580c1.0
  # or 
  yarn add @storybook/test-runner@0.0.5-canary.86.11580c1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
