### PR TITLE
Log a warning if you try and run against a lazy-compiled storybook

### DIFF
--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -23,7 +23,7 @@ process.on('unhandledRejection', (err) => {
   throw err;
 });
 
-const log = (message) => console.log(`[test-storybook] ${message}`)
+const log = (message) => console.log(`[test-storybook] ${message}`);
 
 // Clean up tmp files globally in case of control-c
 let storiesJsonTmpDir;
@@ -112,9 +112,9 @@ async function fetchStoriesJson(url) {
 }
 
 function ejectConfiguration() {
-  const origin = path.resolve(__dirname, '../playwright/test-runner-jest.config.js')
-  const destination = path.resolve('test-runner-jest.config.js')
-  const fileAlreadyExists = fs.existsSync(destination)
+  const origin = path.resolve(__dirname, '../playwright/test-runner-jest.config.js');
+  const destination = path.resolve('test-runner-jest.config.js');
+  const fileAlreadyExists = fs.existsSync(destination);
 
   if (fileAlreadyExists) {
     throw new Error(dedent`Found existing file at:
@@ -122,11 +122,11 @@ function ejectConfiguration() {
     ${destination}
     
     Please delete it and rerun this command.
-    \n`)
+    \n`);
   }
 
-  fs.copyFileSync(origin, destination)
-  log('Configuration file successfully copied as test-runner-jest.config.js')
+  fs.copyFileSync(origin, destination);
+  log('Configuration file successfully copied as test-runner-jest.config.js');
 }
 
 const main = async () => {
@@ -150,12 +150,14 @@ const main = async () => {
   if (!process.env.TEST_BROWSERS && runnerOptions.browsers) {
     process.env.TEST_BROWSERS = runnerOptions.browsers.join(',');
   }
-  const { hostname } = new URL(targetURL)
+  const { hostname } = new URL(targetURL);
 
-  const isLocalStorybookIp = await isLocalhostIp(hostname, true)
-  const shouldRunStoriesJson = runnerOptions.storiesJson !== false && !isLocalStorybookIp
+  const isLocalStorybookIp = await isLocalhostIp(hostname, true);
+  const shouldRunStoriesJson = runnerOptions.storiesJson !== false && !isLocalStorybookIp;
   if (shouldRunStoriesJson) {
-    log('Detected a remote Storybook URL, running in stories json mode. To disable this, run the command again with --no-stories-json')
+    log(
+      'Detected a remote Storybook URL, running in stories json mode. To disable this, run the command again with --no-stories-json'
+    );
   }
 
   if (runnerOptions.storiesJson || shouldRunStoriesJson) {
@@ -166,8 +168,14 @@ const main = async () => {
 
   process.env.STORYBOOK_CONFIG_DIR = runnerOptions.configDir;
 
-  const { storiesPaths } = getStorybookMetadata();
+  const { storiesPaths, lazyCompilation } = getStorybookMetadata();
   process.env.STORYBOOK_STORIES_PATTERN = storiesPaths;
+
+  if (lazyCompilation && isLocalStorybookIp) {
+    log(
+      'Detected a lazy-compiled Storybook. This will likely cause issues; consider disabling `lazyCompilation` for `test-storybook`.'
+    );
+  }
 
   await executeJestPlaywright(jestOptions);
 };

--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -173,7 +173,7 @@ const main = async () => {
 
   if (lazyCompilation && isLocalStorybookIp) {
     log(
-      'Detected a lazy-compiled Storybook. This will likely cause issues; consider disabling `lazyCompilation` for `test-storybook`.'
+      `You're running Storybook with lazy compilation enabled, and will likely cause issues with the test runner locally. Consider disabling 'lazyCompilation' in ${runnerOptions.configDir}/main.js when running 'test-storybook' locally.`
     );
   }
 

--- a/src/util/getStorybookMetadata.test.ts
+++ b/src/util/getStorybookMetadata.test.ts
@@ -65,4 +65,22 @@ describe.only('getStorybookMetadata', () => {
       `"<rootDir>/stories/basic/**/*.stories.@(mdx|tsx|ts|jsx|js);<rootDir>/stories/complex/*.stories.@(js|ts)"`
     );
   });
+
+  it('should return lazyCompilation=false when unset', () => {
+    const mockedMain = { stories: [] };
+
+    jest.spyOn(storybookMain, 'getStorybookMain').mockReturnValueOnce(mockedMain);
+    process.env.STORYBOOK_CONFIG_DIR = '.storybook';
+    expect(getStorybookMetadata().lazyCompilation).toBe(false);
+  });
+  it('should return lazyCompilation=true when set', () => {
+    const mockedMain = {
+      stories: [],
+      core: { builder: { name: 'webpack5', options: { lazyCompilation: true } } },
+    };
+
+    jest.spyOn(storybookMain, 'getStorybookMain').mockReturnValueOnce(mockedMain);
+    process.env.STORYBOOK_CONFIG_DIR = '.storybook';
+    expect(getStorybookMetadata().lazyCompilation).toBe(true);
+  });
 });

--- a/src/util/getStorybookMetadata.ts
+++ b/src/util/getStorybookMetadata.ts
@@ -20,10 +20,14 @@ export const getStorybookMetadata = () => {
     .map((dir) => '<rootDir>/' + relative(workingDir, dir))
     .join(';');
 
+  // @ts-ignore -- this is added in @storybook/core-common@6.5, which we don't depend on
+  const lazyCompilation = !!main?.core?.builder?.options?.lazyCompilation;
+
   return {
     configDir,
     workingDir,
     storiesPaths,
     normalizedStoriesEntries,
+    lazyCompilation,
   };
 };


### PR DESCRIPTION
We want to look into actually working around this problem, but in the meantime, hopefully this will point folks in the right direction.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.6-canary.90.afeeaef.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.0.6-canary.90.afeeaef.0
  # or 
  yarn add @storybook/test-runner@0.0.6-canary.90.afeeaef.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
