### PR TITLE
Add output limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,10 @@ it('button--basic', async () => {
 
 ## Troubleshooting
 
+#### The error output in the CLI is too short
+
+By default, the test runner truncates error outputs at 1000 characters, and you can check the full output directly in Storybook, in the browser. If you do want to change that limit, however, you can do so by setting the `DEBUG_PRINT_LIMIT` environment variable to a number of your choosing, for example, `DEBUG_PRINT_LIMIT=5000 yarn test-storybook`.
+
 #### The test runner seems flaky and keeps timing out
 
 If your tests are timing out with `Timeout - Async callback was not invoked within the 15000 ms timeout specified by jest.setTimeout`, it might be that playwright couldn't handle to test the amount of stories you have in your project. Maybe you have a large amount of stories or your CI has a really low RAM configuration.

--- a/playwright/test-runner-jest.config.js
+++ b/playwright/test-runner-jest.config.js
@@ -2,7 +2,7 @@ const { getJestConfig } = require('@storybook/test-runner');
 
 module.exports = {
   // The default configuration comes from @storybook/test-runner
-  ...getJestConfig()
+  ...getJestConfig(),
   /** Add your own overrides below
    * @see https://jestjs.io/docs/configuration
    */


### PR DESCRIPTION
By default, the test runner will truncate error output at 1000 characters, and you can check the full output directly in Storybook, in the browser. If you do want to change that limit, however, you can do so by setting the `DEBUG_PRINT_LIMIT` environment variable to a number of your choosing, for example, `DEBUG_PRINT_LIMIT=5000 yarn test-storybook`.

Debatable:
1 - Default limit. Currently 1000
2 - Env var name. Currently the same as the one used by testing library, `DEBUG_PRINT_LIMIT`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.7-canary.94.a4889a0.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.0.7-canary.94.a4889a0.0
  # or 
  yarn add @storybook/test-runner@0.0.7-canary.94.a4889a0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
