### PR TITLE
Limit jest to version 26 or 27

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
     "ts-dedent": "^2.0.0"
   },
   "peerDependencies": {
-    "jest": ">=26.6.3"
+    "jest": "^26.6.3 || ^27.0.0"
   }
 }


### PR DESCRIPTION
Currently jest is automatically updated to v28, but this leads to an error:

>TypeError: Jest: Got error running globalSetup - /home/bodo/my-project/node_modules/@storybook/test-runner/playwright/global-setup.js, reason: Class extends value #<Object> is not a constructor or null

So we should limit the version for now.