### PR TITLE
Document limitation for .mdx stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ yarn test-storybook --url https://the-storybook-url-here.com
 
 By default, the test runner transforms your story files into tests. It also supports a secondary "stories.json mode" which runs directly against your Storybook's `stories.json`, a static index of all the stories.
 
-This is particularly useful for running against a deployed storybook because `stories.json` is guaranteed to be in sync with the Storybook you are testing. In the default, story file-based mode, your local story files may be out of sync--or you might not even have access to the source code.
+This is particularly useful for running against a deployed storybook because `stories.json` is guaranteed to be in sync with the Storybook you are testing. In the default, story file-based mode, your local story files may be out of sync--or you might not even have access to the source code. Furthermore, it is not possible to run the test-runner directly against `.mdx` or `.svelte` stories, and stories.json mode must be used.
 
 To run in stories.json mode, first make sure your Storybook has a v3 `stories.json` file. You can navigate to:
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ yarn test-storybook --url https://the-storybook-url-here.com
 
 By default, the test runner transforms your story files into tests. It also supports a secondary "stories.json mode" which runs directly against your Storybook's `stories.json`, a static index of all the stories.
 
-This is particularly useful for running against a deployed storybook because `stories.json` is guaranteed to be in sync with the Storybook you are testing. In the default, story file-based mode, your local story files may be out of sync--or you might not even have access to the source code. Furthermore, it is not possible to run the test-runner directly against `.mdx` or `.svelte` stories, and stories.json mode must be used.
+This is particularly useful for running against a deployed storybook because `stories.json` is guaranteed to be in sync with the Storybook you are testing. In the default, story file-based mode, your local story files may be out of sync--or you might not even have access to the source code. Furthermore, it is not possible to run the test-runner directly against `.mdx` stories, and stories.json mode must be used.
 
 To run in stories.json mode, first make sure your Storybook has a v3 `stories.json` file. You can navigate to:
 


### PR DESCRIPTION
I was scratching my head for a bit as to why I was getting an error that no tests were found, when I had a `.stories.mdx` file that I assumed would be picked up.  According to https://github.com/storybookjs/test-runner/issues/36, `--stories-json` mode should be used to enable running tests against such stories.

This adds a brief note in the README about this, though it might be good to clearly document exactly which tests this _does_ support out of the box, and point to stories.json mode for others.  But, I'll admit that I'm not clear on exactly what is supported myself.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.8-canary.102.5ccece6.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.0.8-canary.102.5ccece6.0
  # or 
  yarn add @storybook/test-runner@0.0.8-canary.102.5ccece6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
