### PR TITLE
Add Jest compatibility check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-  "deepscan.enable": true
+  "deepscan.enable": true,
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#00333B",
+    "titleBar.activeBackground": "#004752",
+    "titleBar.activeForeground": "#ECFCFF"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -316,6 +316,17 @@ it('button--basic', async () => {
 
 ## Troubleshooting
 
+#### Errors with Jest 28
+
+Jest 28 has been released, but unfortunately `jest-playwright` is not yet compatible with it, therefore the test-runner is also not compatible. You likely are having an issue that looks like this:
+
+```sh
+  TypeError: Jest: Got error running globalSetup
+  reason: Class extends value #<Object> is not a constructor or null
+```
+
+As soon as `jest-playwright` is compatible, so the test-runner will be too. Please follow [this issue](https://github.com/storybookjs/test-runner/issues/99) for updates.
+
 #### The error output in the CLI is too short
 
 By default, the test runner truncates error outputs at 1000 characters, and you can check the full output directly in Storybook, in the browser. If you do want to change that limit, however, you can do so by setting the `DEBUG_PRINT_LIMIT` environment variable to a number of your choosing, for example, `DEBUG_PRINT_LIMIT=5000 yarn test-storybook`.

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "jest-watch-typeahead": "^1.0.0",
     "node-fetch": "^2",
     "playwright": "^1.14.0",
+    "semver": "^7.3.7",
     "tempy": "^1.0.1",
     "ts-dedent": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11062,7 +11062,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.x, semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==


### PR DESCRIPTION
Unfortunately the test runner is not compatible with Jest 28 and will not be until https://github.com/playwright-community/jest-playwright/issues/796 is resolved. 

This PR adds a check to warn and prevent users from running into compatibility issues