### PR TITLE
Updates readme to lock Jest to version 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ yarn add @storybook/test-runner -D
 Jest is a peer dependency. If you don't have it, also install it
 
 ```jsx
-yarn add jest@27.5.1 -D
+yarn add jest@27 -D
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ yarn add @storybook/test-runner -D
 Jest is a peer dependency. If you don't have it, also install it
 
 ```jsx
-yarn add jest -D
+yarn add jest@27.5.1 -D
 ```
 
 <details>


### PR DESCRIPTION
With this pull request, the Readme is updated to lock Jest to version 27.5.1 to prevent issues with the latest release