### PR TITLE
chore(DEPS): update jest-playwright-preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "commander": "^9.0.0",
     "global": "^4.4.0",
     "is-localhost-ip": "^1.4.0",
-    "jest-playwright-preset": "^1.7.0",
+    "jest-playwright-preset": "^1.7.2",
     "jest-serializer-html": "^7.1.0",
     "jest-watch-typeahead": "^1.0.0",
     "node-fetch": "^2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6198,10 +6198,10 @@ expand-tilde@^1.2.2:
   dependencies:
     os-homedir "^1.0.1"
 
-expect-playwright@^0.7.0:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/expect-playwright/-/expect-playwright-0.7.2.tgz#e1f2c31cd0d13d04e1ba4136019613ad01f6ea43"
-  integrity sha512-5o9si+8SUi68QVI0CRVv8tvTjZinpJWRSfQ3GP6v0DvlK55lDgFvD79r6A/NU+EUawrBc62qP30MxzOUnXNJZQ==
+expect-playwright@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/expect-playwright/-/expect-playwright-0.8.0.tgz#6d4ebe0bdbdd3c1693d880d97153b96a129ae4e8"
+  integrity sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==
 
 expect@^27.5.1:
   version "27.5.1"
@@ -8260,12 +8260,12 @@ jest-mock@^27.0.6, jest-mock@^27.3.0, jest-mock@^27.5.1:
     "@jest/types" "^27.5.1"
     "@types/node" "*"
 
-jest-playwright-preset@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/jest-playwright-preset/-/jest-playwright-preset-1.7.0.tgz#bd5998d1a9090fdf68a9dc4421da4c0d45f9156c"
-  integrity sha512-G25Nik+By0SNniMDdkouDL/yA1LdqjzsXNSVU4xnRX1typjXRmzRE0aSgqxas2sRi8cwG3M1ioHdkLLsp6sang==
+jest-playwright-preset@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/jest-playwright-preset/-/jest-playwright-preset-1.7.2.tgz#708942c4dcc1edc85429079d2b47a9382298c454"
+  integrity sha512-0M7M3z342bdKQLnS70cIptlJsW+uuGptbPnqIMg4K5Vp/L/DhqdTKZK7WM4n6miAUnZdUcjXKOdQWfZW/aBo7w==
   dependencies:
-    expect-playwright "^0.7.0"
+    expect-playwright "^0.8.0"
     jest-process-manager "^0.3.1"
     nyc "^15.1.0"
     playwright-core ">=1.2.0"


### PR DESCRIPTION
The new version 1.7.1 has limited the version range for jest to <28.

Cf. https://github.com/playwright-community/jest-playwright/issues/793