### PR TITLE
Document need for a custom snapshotResolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ module.exports = {
 };
 ```
 
-As snapshots by default get stored alongside the test file, and tests get generated in a temporary folder, you will need to `--eject` and configure a custom [`snapshotResolver`](https://jestjs.io/docs/configuration#snapshotresolver-string) like this:
+When running with `--stories-json`, tests get generated in a temporary folder and snapshots get stored alongside. You will need to `--eject` and configure a custom [`snapshotResolver`](https://jestjs.io/docs/configuration#snapshotresolver-string) to store them elsewhere, e.g. in your working directory:
 
 ```js
 const path = require('path');

--- a/README.md
+++ b/README.md
@@ -355,6 +355,20 @@ module.exports = {
 };
 ```
 
+As snapshots by default get stored alongside the test file, and tests get generated in a temporary folder, you will need to `--eject` and configure a custom [`snapshotResolver`](https://jestjs.io/docs/configuration#snapshotresolver-string) like this:
+
+```js
+const path = require('path');
+
+module.exports = {
+  resolveSnapshotPath: (testPath, snapshotExtension) =>
+    path.join(process.cwd(), '__snapshots__', path.basename(testPath) + snapshotExtension),
+  resolveTestPath: (snapshotFilePath, snapshotExtension) =>
+    path.join(process.env.TEST_ROOT, path.basename(snapshotFilePath, snapshotExtension)),
+  testPathForConsistencyCheck: path.join(process.env.TEST_ROOT, 'example.test.js'),
+};
+```
+
 ### Image snapshot recipe
 
 Here's a slightly different recipe for image snapshot testing:


### PR DESCRIPTION
I noticed that (DOM) snapshots get stored alongside with the generated tests, and since they get generated in a temporary folder, that doesn't work.

Fortunately Jest supports a custom `snapshotResolver`, so I updated the README with instructions on how to use that.