### PR TITLE
feat: add console logs on test failure

### DIFF
--- a/src/setup-page.ts
+++ b/src/setup-page.ts
@@ -166,7 +166,8 @@ export const setupPage = async (page) => {
         // collect logs to show upon test error
         let logs = [];
 
-        const spyOnConsole = (originalFn, name) => {
+        const spyOnConsole = (method, name) => {
+          const originalFn = console[method];
           return function () {
             const message = [...arguments].map(composeMessage).join(', ');
             const prefix = \`\${bold(name)}: \`;
@@ -175,10 +176,19 @@ export const setupPage = async (page) => {
           };
         };
 
-        console.log = spyOnConsole(console.log, blue('log'));
-        console.warn = spyOnConsole(console.warn, yellow('warn'));
-        console.error = spyOnConsole(console.error, red('error'));
-        console.trace = spyOnConsole(console.trace, magenta('trace'));
+        // console methods + color function for their prefix
+        const spiedMethods = {
+          log: blue,
+          warn: yellow,
+          error: red,
+          trace: magenta,
+          group: magenta,
+          groupCollapsed: magenta,
+        }
+        
+        Object.entries(spiedMethods).forEach(([method, color]) => {
+          console[method] = spyOnConsole(method, color(method))
+        })
 
         return new Promise((resolve, reject) => {
           channel.on('${renderedEvent}', () => resolve(document.getElementById('root')));

--- a/src/setup-page.ts
+++ b/src/setup-page.ts
@@ -106,7 +106,7 @@ export const setupPage = async (page) => {
           const storyUrl = \`${referenceURL || targetURL}?path=/story/\${storyId}\`;
           const finalStoryUrl = \`\${storyUrl}&addonPanel=storybook/interactions/panel\`;
           const separator = '\\n\\n--------------------------------------------------';
-          const extraLogs = logs.length > 0 ? separator + "\\n\\nBrowser logs:\\n\\n"+ logs.join('\\n') : '';
+          const extraLogs = logs.length > 0 ? separator + "\\n\\nBrowser logs:\\n\\n"+ logs.join('\\n\\n') : '';
 
           this.message = \`\nAn error occurred in the following story. Access the link for full output:\n\${finalStoryUrl}\n\nMessage:\n \${truncate(errorMessage,${debugPrintLimit})}\n\${extraLogs}\`;
         }


### PR DESCRIPTION
Issue: #155 

For now, the feature is always enabled. It only provides the logs when there are failures.

Here's a code example:

```js
export const Logs = (args) => {
  console.log("here's an object", { hello: "world" })
  console.warn("The API is deprecated!")
  console.error("Some error happened.")

  return (
    <button type="button" onClick={() => args.onSubmit('clicked')}>
      Click
    </button>
  )
};
Logs.play = async ({ args, canvasElement }) => {
  console.log("log from play function")
  await userEvent.click(within(canvasElement).getByRole('buttons')); // <-- will fail
  await expect(args.onSubmit).toHaveBeenCalledWith(expect.stringMatching(/([A-Z])\w+/gi));
};
```

And here's the output:
![image](https://user-images.githubusercontent.com/1671563/182476393-e68f3498-a93c-43c1-afa2-b018b6d0a679.png)

Here's how it looks like on a more realistic scenario:

![image](https://user-images.githubusercontent.com/1671563/183098275-11de11ba-e0b6-4641-a3d5-a021bdcd6247.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.0--canary.157.66af119.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.6.0--canary.157.66af119.0
  # or 
  yarn add @storybook/test-runner@0.6.0--canary.157.66af119.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


## Release notes

#### Features

[feat: add console logs on test failure](https://github.com/storybookjs/test-runner/pull/157#top)
This version adds console logs to the output of failed tests, in order to as provide as much information as possible to help you diagnose your issues. 
