### PR TITLE
docs(README): Update a11y recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ You can use it for multiple use cases, and here's an example that combines the s
 ```js
 // .storybook/test-runner.js
 const { getStoryContext } = require('@storybook/test-runner');
-const { injectAxe, checkA11y } = require('axe-playwright');
+const { injectAxe, checkA11y, configureAxe } = require('axe-playwright');
 
 module.exports = {
   async preRender(page, context) {
@@ -502,6 +502,11 @@ module.exports = {
     if (storyContext.parameters?.a11y?.disable) {
       return;
     }
+
+    // Apply story-level a11y rules
+    await configureAxe(page, {
+      rules: storyContext.parameters?.a11y?.config?.rules,
+    })
 
     // from Storybook 7.0 onwards, the selector should be #storybook-root
     await checkA11y(page, '#root', {


### PR DESCRIPTION
Added code example in Readme of Global utility functions. 
The reason is that when a11y rule is configured on story level, the rules are applied in the local Storybook instance but when run test-storybook in command line, those rules are ignored and throws violations i.  e.g.) Disabling some rules using rule ID.  

Because of that, we need to configure configureAxe() and before a11y test runs. 

I added the example since there is no documentation for the configuration, and I belive there would be a common configuration case if developers override a11y rules on story base.

This is the discussion about the case. https://discord.com/channels/486522875931656193/580149748225409024/1007635983707156571