### PR TITLE
Fix StorybookTestRunnerError – length on undefined

### DIFF
--- a/src/setup-page.ts
+++ b/src/setup-page.ts
@@ -103,7 +103,7 @@ export const setupPage = async (page: Page) => {
       }
       
       class StorybookTestRunnerError extends Error {
-        constructor(storyId, errorMessage, logs) {
+        constructor(storyId, errorMessage, logs = []) {
           super(errorMessage);
           this.name = 'StorybookTestRunnerError';
           const storyUrl = \`${referenceURL || targetURL}?path=/story/\${storyId}\`;


### PR DESCRIPTION
When running `yarn test-storybook` on my story, a 3rd party library throws an uncaught exception, but `StorybookTestRunnerError` _assumes_ `logs` is an array, which throws this error:

```console
UnhandledPromiseRejectionWarning: page.evaluate: TypeError: Cannot read properties of undefined (reading 'length')
    at new StorybookTestRunnerError (<anonymous>:58:34)
    at __throwError (<anonymous>:71:15)
    at eval (eval at evaluate (:192:30), <anonymous>:4:19)
    at UtilityScript.evaluate (<anonymous>:194:17)
    at UtilityScript.<anonymous> (<anonymous>:1:44)
```

This PR simply **defaults `logs` to `[]`**, so I can correctly see that the underlying error is _actually_ coming from a 3rd party library:

```console
 Cannot read properties of null (reading 'focus')
```