### PR TITLE
Fix nightly check for failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           run: |
             yarn build
-            yarn test-storybook:ci-failures
+            ! yarn test-storybook:ci-failures
 
       - name: Process test results
         if: ${{ always() }}


### PR DESCRIPTION
Make sure that the exit code from `test-storybook:ci-failures` is inverted