### PR TITLE
Improve error logging and ensure non-zero exit

### DIFF
--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -274,4 +274,7 @@ const main = async () => {
   await executeJestPlaywright(jestOptions);
 };
 
-main().catch((e) => log(e));
+main().catch((e) => {
+  error(e);
+  process.exit(1);
+});

--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -26,7 +26,13 @@ process.on('unhandledRejection', (err) => {
 });
 
 const log = (message) => console.log(`[test-storybook] ${message}`);
-const error = (message) => console.error(`[test-storybook] ${message}`);
+const error = (err) => {
+  if (err instanceof Error) {
+    console.error(`[test-storybook] ${err.message} \n\n${err.stack}`);
+  } else {
+    console.error(`[test-storybook] ${err}`);
+  }
+};
 
 // Clean up tmp files globally in case of control-c
 let indexTmpDir;

--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -9,7 +9,8 @@ const fs = require('fs');
 const dedent = require('ts-dedent').default;
 const path = require('path');
 const tempy = require('tempy');
-const { getCliOptions, getStorybookMetadata } = require('../dist/cjs/util');
+const { getCliOptions } = require('../dist/cjs/util/getCliOptions');
+const { getStorybookMetadata } = require('../dist/cjs/util/getStorybookMetadata');
 const { transformPlaywrightJson } = require('../dist/cjs/playwright/transformPlaywrightJson');
 
 // Do this as the first thing so that any code reading it knows the right env.

--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -29,9 +29,9 @@ process.on('unhandledRejection', (err) => {
 const log = (message) => console.log(`[test-storybook] ${message}`);
 const error = (err) => {
   if (err instanceof Error) {
-    console.error(`[test-storybook] ${err.message} \n\n${err.stack}`);
+    console.error(`\x1b[31m[test-storybook]\x1b[0m ${err.message} \n\n${err.stack}`);
   } else {
-    console.error(`[test-storybook] ${err}`);
+    console.error(`\x1b[31m[test-storybook]\x1b[0m ${err}`);
   }
 };
 
@@ -129,7 +129,7 @@ async function checkStorybook(url) {
     if (res.status !== 200) throw new Error(`Unxpected status: ${res.status}`);
   } catch (e) {
     console.error(
-      dedent`[test-storybook] It seems that your Storybook instance is not running at: ${url}. Are you sure it's running?
+      dedent`\x1b[31m[test-storybook]\x1b[0m It seems that your Storybook instance is not running at: ${url}. Are you sure it's running?
       
       If you're not running Storybook on the default 6006 port or want to run the tests against any custom URL, you can pass the --url flag like so:
       


### PR DESCRIPTION
I was getting an error when running the test-runner, but it did not fail CI because an exit code of `0` was being returned.  Also, the error message did not have any stack trace or other information, so it was nearly impossible to tell why it was failing.

This PR adds a stacktrace to the error message returned, and ensures that we exit with a non-zero code, so that CI fails correctly.  I also made the title red, just because I think it helps a little for clarity.

Before: 
<img width="797" alt="image" src="https://user-images.githubusercontent.com/4616705/194593870-b288dbb5-24da-4499-ac2e-36158fc18e79.png">

After: 
<img width="784" alt="image" src="https://user-images.githubusercontent.com/4616705/194593813-b2d9b540-bd1d-4cbf-a6a8-af8125906ff4.png">

Underlying issue causing this error: https://github.com/storybookjs/test-runner/issues/200

Oh, and I fixed some import paths.  I think the actual imports were working before, but typescript couldn't find them, I guess due to the way that the compiled babel output converted `export * from`.

<img width="644" alt="image" src="https://user-images.githubusercontent.com/4616705/194595912-330d8f81-8e3f-49f2-be88-e750e9b5f792.png">