### PR TITLE
Upgrade to next instead of future

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,9 +29,9 @@ jobs:
           echo "prev_sb_version=$(yarn list @storybook/react --depth=0 2> /dev/null | grep @storybook/react | awk -F'@' '{print $3}')" >> $GITHUB_ENV
           echo "prev_sb_csf_version=$(yarn list @storybook/csf --depth=0 2> /dev/null | grep @storybook/csf | awk -F'@' '{print $3}')" >> $GITHUB_ENV
 
-      - name: Upgrade to storybook@future
+      - name: Upgrade to storybook@next
         run: |
-          npx storybook@future upgrade --prerelease --yes
+          npx storybook@next upgrade --prerelease --yes
 
       # TODO: This should not be necessary once @storybook/csf is properly updated
       - name: Fix local @storybook/csf version
@@ -115,9 +115,9 @@ jobs:
           echo "prev_sb_version=$(yarn list @storybook/react --depth=0 2> /dev/null | grep @storybook/react | awk -F'@' '{print $3}')" >> $GITHUB_ENV
           echo "prev_sb_csf_version=$(yarn list @storybook/csf --depth=0 2> /dev/null | grep @storybook/csf | awk -F'@' '{print $3}')" >> $GITHUB_ENV
 
-      - name: Upgrade to storybook@future
+      - name: Upgrade to storybook@next
         run: |
-          npx storybook@future upgrade --prerelease --yes
+          npx storybook@next upgrade --prerelease --yes
 
       # TODO: This should not be necessary once @storybook/csf is properly updated
       - name: Fix local @storybook/csf version


### PR DESCRIPTION
SB monorepo is now publishing to `next` instead of `future`, so use that to get the latest version of the automigrations
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.1--canary.211.3eb9f74.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.9.1--canary.211.3eb9f74.0
  # or 
  yarn add @storybook/test-runner@0.9.1--canary.211.3eb9f74.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
