### PR TITLE
Docs: add recipe for browser name

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,8 @@ module.exports = {
     expect.extend({ toMatchImageSnapshot });
   },
   async postRender(page, context) {
+    // If you want to take screenshot of multiple browsers, use
+    // page.context().browser().browserType().name() to get the browser name to prefix the file name
     const image = await page.screenshot();
     expect(image).toMatchImageSnapshot({
       customSnapshotsDir,


### PR DESCRIPTION
Issue: #220

So users can prefix their file names