### PR TITLE
Add Ability To Provide Custom HTTP Headers For Storybook Endpoint

### DIFF
--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -123,9 +123,9 @@ async function executeJestPlaywright(args) {
   await jest.run(argv);
 }
 
-async function checkStorybook(url) {
+async function checkStorybook(url, headers) {
   try {
-    const res = await fetch(url, { method: 'HEAD' });
+    const res = await fetch(url, { method: 'HEAD', headers });
     if (res.status !== 200) throw new Error(`Unxpected status: ${res.status}`);
   } catch (e) {
     console.error(
@@ -223,7 +223,8 @@ const main = async () => {
   isWatchMode = jestOptions.watch || jestOptions.watchAll;
 
   const rawTargetURL = process.env.TARGET_URL || runnerOptions.url || 'http://localhost:6006';
-  await checkStorybook(rawTargetURL);
+  const headers = !!runnerOptions.headers ? JSON.parse(runnerOptions.headers) : {};
+  await checkStorybook(rawTargetURL, headers);
 
   const targetURL = sanitizeURL(rawTargetURL);
 

--- a/src/util/getCliOptions.ts
+++ b/src/util/getCliOptions.ts
@@ -10,6 +10,10 @@ type CliOptions = {
     coverage?: boolean;
     junit?: boolean;
     browsers?: BrowserType | BrowserType[];
+    /**
+     * Stringified JSON
+     */
+    headers?: string;
   };
   jestOptions: string[];
 };
@@ -24,6 +28,7 @@ const STORYBOOK_RUNNER_COMMANDS: StorybookRunnerCommand[] = [
   'url',
   'coverage',
   'junit',
+  'headers',
 ];
 
 export const getCliOptions = () => {

--- a/src/util/getParsedCliOptions.ts
+++ b/src/util/getParsedCliOptions.ts
@@ -60,6 +60,10 @@ export const getParsedCliOptions = () => {
     .option(
       '--ci',
       'Instead of the regular behavior of storing a new snapshot automatically, it will fail the test and require to be run with --updateSnapshot.'
+    )
+    .option(
+      '--headers <headers>',
+      'Additional headers passed to storybook endpoint. Useful for remote storybook deployments behind Basic Auth.'
     );
 
   program.exitOverride();


### PR DESCRIPTION
For storybook deployments that are behind authentication, such as Basic Auth, while playwright supports defining httpCredentials or custom headers, the initial check done by this test runner fails since it only runs a very simple check against the URL.

This PR adds the ability to define custom headers for the test runner so that it can properly verify URL in these cases, and the test runs will use playwright's config afterwards.