### PR TITLE
feature: add an option for the iframe.html to be loaded with instrument=true

### DIFF
--- a/src/setup-page.ts
+++ b/src/setup-page.ts
@@ -41,7 +41,8 @@ export const setupPage = async (page: Page) => {
     );
   }
 
-  const iframeURL = new URL('iframe.html', process.env.TARGET_URL).toString();
+  const pageName = process.env.INSTRUMENT ? 'iframe.html' : 'iframe.html?instrument=true';
+  const iframeURL = new URL(pageName, process.env.TARGET_URL).toString();
   await page.goto(iframeURL, { waitUntil: 'load' }).catch((err) => {
     if (err.message?.includes('ERR_CONNECTION_REFUSED')) {
       const errorMessage = `Could not access the Storybook instance at ${targetURL}. Are you sure it's running?\n\n${err.message}`;


### PR DESCRIPTION
In order for [storybook's instrumenter](https://www.npmjs.com/package/@storybook/instrumenter) to be run on the `iframe.html` page, the GET parameter `instrument=true` must be included on the page. The test-runner addon currently does not provide this option when running the tests and therefore the instrumenter does not run under test-runner.

This change adds the option of enabling the instrumenter, using the `process.env.INSTRUMENT` option, which adds the `instrument=true` GET variable to the iframe URL.