### PR TITLE
feat: add shard cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Usage: test-storybook [options]
 | `--outputFile`                  | Write test results to a file when the --json option is also specified. <br/>`test-storybook --json --outputFile results.json`                                                 |
 | `--junit`                       | Indicates that test information should be reported in a junit file. <br/>`test-storybook --**junit**`                                                                         |
 | `--ci`                          | Instead of the regular behavior of storing a new snapshot automatically, it will fail the test and require Jest to be run with `--updateSnapshot`. <br/>`test-storybook --ci` |
+| `--shard [shardIndex/shardCount]` | Splits your test suite across different machines to run in CI. <br/>`test-storybook --shard=1/3` |
 
 ## Ejecting configuration
 

--- a/src/util/getParsedCliOptions.ts
+++ b/src/util/getParsedCliOptions.ts
@@ -60,6 +60,10 @@ export const getParsedCliOptions = () => {
     .option(
       '--ci',
       'Instead of the regular behavior of storing a new snapshot automatically, it will fail the test and require to be run with --updateSnapshot.'
+    )
+    .option(
+      '--shard <shardIndex/shardCount>',
+      'Splits your test suite across different machines to run in CI.'
     );
 
   program.exitOverride();


### PR DESCRIPTION
Add cli-only option `--shard` [from Jest](https://jestjs.io/docs/28.x/cli#--shard) to allow running a subset of tests across multiple machines in parallel in CI.

Example:
```
yarn test-storybook --shard=1/3
```