### PR TITLE
Use ipv4 loopback address

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ yarn test-storybook
 > **NOTE:** The runner assumes that your Storybook is running on port `6006`. If you're running Storybook in another port, either use --url or set the TARGET_URL before running your command like:
 >
 > ```jsx
-> yarn test-storybook --url http://localhost:9009
+> yarn test-storybook --url http://127.0.0.1:9009
 > or
-> TARGET_URL=http://localhost:9009 yarn test-storybook
+> TARGET_URL=http://127.0.0.1:9009 yarn test-storybook
 > ```
 
 ## CLI Options

--- a/bin/test-storybook.js
+++ b/bin/test-storybook.js
@@ -133,7 +133,7 @@ async function checkStorybook(url) {
       
       If you're not running Storybook on the default 6006 port or want to run the tests against any custom URL, you can pass the --url flag like so:
       
-      yarn test-storybook --url http://localhost:9009
+      yarn test-storybook --url http://127.0.0.1:9009
       
       More info at https://github.com/storybookjs/test-runner#getting-started`
     );
@@ -222,7 +222,7 @@ const main = async () => {
   // set this flag to skip reporting coverage in watch mode
   isWatchMode = jestOptions.watch || jestOptions.watchAll;
 
-  const rawTargetURL = process.env.TARGET_URL || runnerOptions.url || 'http://localhost:6006';
+  const rawTargetURL = process.env.TARGET_URL || runnerOptions.url || 'http://127.0.0.1:6006';
   await checkStorybook(rawTargetURL);
 
   const targetURL = sanitizeURL(rawTargetURL);

--- a/src/util/getParsedCliOptions.ts
+++ b/src/util/getParsedCliOptions.ts
@@ -27,7 +27,7 @@ export const getParsedCliOptions = () => {
     .option(
       '--url <url>',
       'Define the URL to run tests in. Useful for custom Storybook URLs',
-      'http://localhost:6006'
+      'http://127.0.0.1:6006'
     )
     .option(
       '--maxWorkers <amount>',


### PR DESCRIPTION
I tried to update my app to Node 18, and found that the test-runner started to fail.  I learned it was because of a [change](https://github.com/nodejs/node/pull/39987) in Node 17 to no longer sort the results of `getaddrinfo` to prefer ipv4 addresses.  This means on some machines after node 17, `localhost` no longer resolves to `127.0.0.1`.  

Therefore, running `http-server storybook-static --port 6006` and then `test-storybook` will no longer work, because `localhost` is looking for an ipv6 address, and http-server sets up on ipv4.

As a workaround, I can use `--url http://127.0.0.1:6006`, but that seems like it shouldn't be necessary.  

So this change looks for `127.0.0.1` explicitly as the default, and updates the documentation to reference it that way as well.  I tested this back to node 16 and of course it works fine there too.

This should make it a bit easier for folks to upgrade to node 18 without nasty surprises.

