### PR TITLE
Update getStorybookMain to throw an error if stories are not found in main.js

### DIFF
--- a/src/util/__snapshots__/getStorybookMain.test.ts.snap
+++ b/src/util/__snapshots__/getStorybookMain.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getStorybookMain no stories should throw an error if no stories are defined 1`] = `
+"Could not find stories in main.js in .storybook. 
+If you are using a mono-repository, please run the test-runner only against your sub-package, which contains a .storybook folder with \\"stories\\" defined in main.js.
+You can change the config directory by using --config-dir <path-to-dir>"
+`;
+
+exports[`getStorybookMain no stories should throw an error if stories list is empty 1`] = `
+"Could not find stories in main.js in .storybook. 
+If you are using a mono-repository, please run the test-runner only against your sub-package, which contains a .storybook folder with \\"stories\\" defined in main.js.
+You can change the config directory by using --config-dir <path-to-dir>"
+`;
+
+exports[`getStorybookMain should throw an error if no configuration is found 1`] = `"Could not load main.js in .storybook. Is the config directory correct? You can change it by using --config-dir <path-to-dir>"`;

--- a/src/util/getStorybookMain.test.ts
+++ b/src/util/getStorybookMain.test.ts
@@ -1,11 +1,29 @@
-import { getStorybookMain } from './getStorybookMain';
+import { getStorybookMain, resetStorybookMainCache } from './getStorybookMain';
 import * as coreCommon from '@storybook/core-common';
 
 jest.mock('@storybook/core-common');
 
 describe('getStorybookMain', () => {
+  beforeEach(() => {
+    resetStorybookMainCache();
+  });
+
   it('should throw an error if no configuration is found', () => {
-    expect(() => getStorybookMain('.storybook')).toThrow();
+    expect(() => getStorybookMain('.storybook')).toThrowErrorMatchingSnapshot();
+  });
+
+  describe('no stories', () => {
+    it('should throw an error if no stories are defined', () => {
+      jest.spyOn(coreCommon, 'serverRequire').mockImplementation(() => ({}));
+
+      expect(() => getStorybookMain('.storybook')).toThrowErrorMatchingSnapshot();
+    });
+
+    it('should throw an error if stories list is empty', () => {
+      jest.spyOn(coreCommon, 'serverRequire').mockImplementation(() => ({ stories: [] }));
+
+      expect(() => getStorybookMain('.storybook')).toThrowErrorMatchingSnapshot();
+    });
   });
 
   it('should return mainjs', () => {

--- a/src/util/getStorybookMain.ts
+++ b/src/util/getStorybookMain.ts
@@ -1,20 +1,38 @@
 import { join, resolve } from 'path';
 import { serverRequire } from '@storybook/core-common';
 import type { StorybookConfig } from '@storybook/types';
+import dedent from 'ts-dedent';
 
-let storybookMainConfig: StorybookConfig;
+let storybookMainConfig = new Map<string, StorybookConfig>();
 
 export const getStorybookMain = (configDir: string) => {
-  if (storybookMainConfig) {
-    return storybookMainConfig;
+  if (storybookMainConfig.has(configDir)) {
+    return storybookMainConfig.get(configDir);
+  } else {
+    storybookMainConfig.set(configDir, serverRequire(join(resolve(configDir), 'main')));
   }
 
-  storybookMainConfig = serverRequire(join(resolve(configDir), 'main'));
-  if (!storybookMainConfig) {
+  const mainConfig = storybookMainConfig.get(configDir);
+
+  if (!mainConfig) {
     throw new Error(
       `Could not load main.js in ${configDir}. Is the config directory correct? You can change it by using --config-dir <path-to-dir>`
     );
   }
 
-  return storybookMainConfig;
+  if (!mainConfig.stories || mainConfig.stories.length === 0) {
+    throw new Error(
+      dedent`
+        Could not find stories in main.js in ${configDir}. 
+        If you are using a mono-repository, please run the test-runner only against your sub-package, which contains a .storybook folder with "stories" defined in main.js.
+        You can change the config directory by using --config-dir <path-to-dir>
+        `
+    );
+  }
+
+  return mainConfig;
 };
+
+export function resetStorybookMainCache() {
+  storybookMainConfig.clear();
+}


### PR DESCRIPTION
Closes https://github.com/storybookjs/test-runner/issues/277

## What I did

Updated getStorybookMain to throw an error if stories are not found in main.js
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.5--canary.278.4ef4cb1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.9.5--canary.278.4ef4cb1.0
  # or 
  yarn add @storybook/test-runner@0.9.5--canary.278.4ef4cb1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
