### PR TITLE
fix(playwright): Update transform.js to load presets using require.resolve

### DIFF
--- a/playwright/transform.js
+++ b/playwright/transform.js
@@ -10,7 +10,7 @@ module.exports = {
       babelrc: false,
       configFile: false,
       presets: [
-        require.resolve("@babel/preset-env", { targets: { node: 'current' } }),
+        require.resolve('@babel/preset-env', { targets: { node: 'current' } }),
         require.resolve('@babel/preset-typescript'),
         require.resolve('@babel/preset-react'),
       ],

--- a/playwright/transform.js
+++ b/playwright/transform.js
@@ -10,9 +10,9 @@ module.exports = {
       babelrc: false,
       configFile: false,
       presets: [
-        ['@babel/preset-env', { targets: { node: 'current' } }],
-        '@babel/preset-typescript',
-        '@babel/preset-react',
+        require.resolve("@babel/preset-env", { targets: { node: 'current' } }),
+        require.resolve('@babel/preset-typescript'),
+        require.resolve('@babel/preset-react'),
       ],
     });
 


### PR DESCRIPTION
**What problem does this PR address?**
This PR addresses [[Bug] Module resolution in transform.js #280](https://github.com/storybookjs/test-runner/issues/280)

**How does it solve the problem?**
Updates `transform` module to use require.resolve in loading the `presets`.

**Has this change been tested?**
Yes.