### PR TITLE
fix: Remove last reference to regenerator-runtime

### DIFF
--- a/playwright/custom-environment.js
+++ b/playwright/custom-environment.js
@@ -1,6 +1,5 @@
 const { setupPage } = require('../dist/setup-page');
 
-require('regenerator-runtime/runtime');
 const PlaywrightEnvironment = require('jest-playwright-preset/lib/PlaywrightEnvironment').default;
 
 class CustomEnvironment extends PlaywrightEnvironment {


### PR DESCRIPTION
There was one line of code still referencing regenerator-runtime. It's no longer used.
Fixes: #304
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.1--canary.303.86f873e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.10.1--canary.303.86f873e.0
  # or 
  yarn add @storybook/test-runner@0.10.1--canary.303.86f873e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
