### PR TITLE
Fix extra args not being passed to jest

### DIFF
--- a/src/util/getCliOptions.test.ts
+++ b/src/util/getCliOptions.test.ts
@@ -10,4 +10,11 @@ describe('getCliOptions', () => {
     const opts = getCliOptions();
     expect(opts.runnerOptions).toMatchObject(customConfig);
   });
+
+  it('returns extra args if passed', () => {
+    const extraArgs = ['TestName', 'AnotherTestName'];
+    jest.spyOn(cliHelper, 'getParsedCliOptions').mockReturnValue({ options: {}, extraArgs });
+    const opts = getCliOptions();
+    expect(opts.jestOptions).toEqual(extraArgs);
+  });
 });

--- a/src/util/getCliOptions.test.ts
+++ b/src/util/getCliOptions.test.ts
@@ -2,6 +2,12 @@ import { getCliOptions } from './getCliOptions';
 import * as cliHelper from './getParsedCliOptions';
 
 describe('getCliOptions', () => {
+  let originalArgv: string[] = process.argv;
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
   it('returns custom options if passed', () => {
     const customConfig = { configDir: 'custom', indexJson: true };
     jest
@@ -13,6 +19,9 @@ describe('getCliOptions', () => {
 
   it('returns extra args if passed', () => {
     const extraArgs = ['TestName', 'AnotherTestName'];
+    // mock argv to avoid side effect from running tests e.g. jest --coverage,
+    // which would end up caught by getCliOptions
+    process.argv = [];
     jest.spyOn(cliHelper, 'getParsedCliOptions').mockReturnValueOnce({ options: {}, extraArgs });
     const opts = getCliOptions();
     expect(opts.jestOptions).toEqual(extraArgs);

--- a/src/util/getCliOptions.test.ts
+++ b/src/util/getCliOptions.test.ts
@@ -6,14 +6,14 @@ describe('getCliOptions', () => {
     const customConfig = { configDir: 'custom', indexJson: true };
     jest
       .spyOn(cliHelper, 'getParsedCliOptions')
-      .mockReturnValue({ options: customConfig, extraArgs: [] });
+      .mockReturnValueOnce({ options: customConfig, extraArgs: [] });
     const opts = getCliOptions();
     expect(opts.runnerOptions).toMatchObject(customConfig);
   });
 
   it('returns extra args if passed', () => {
     const extraArgs = ['TestName', 'AnotherTestName'];
-    jest.spyOn(cliHelper, 'getParsedCliOptions').mockReturnValue({ options: {}, extraArgs });
+    jest.spyOn(cliHelper, 'getParsedCliOptions').mockReturnValueOnce({ options: {}, extraArgs });
     const opts = getCliOptions();
     expect(opts.jestOptions).toEqual(extraArgs);
   });

--- a/src/util/getCliOptions.ts
+++ b/src/util/getCliOptions.ts
@@ -1,7 +1,7 @@
 import { getParsedCliOptions } from './getParsedCliOptions';
 import type { BrowserType } from 'jest-playwright-preset';
 
-export type JestOptions = any[];
+export type JestOptions = string[];
 
 export type CliOptions = {
   runnerOptions: {

--- a/src/util/getCliOptions.ts
+++ b/src/util/getCliOptions.ts
@@ -1,9 +1,7 @@
 import { getParsedCliOptions } from './getParsedCliOptions';
 import type { BrowserType } from 'jest-playwright-preset';
 
-export type JestOptions = {
-  [key: string]: any;
-};
+export type JestOptions = any[];
 
 export type CliOptions = {
   runnerOptions: {
@@ -63,7 +61,7 @@ export const getCliOptions = (): CliOptions => {
   }, defaultOptions);
 
   if (extraArgs.length) {
-    finalOptions.jestOptions.push(...[extraArgs]);
+    finalOptions.jestOptions.push(...extraArgs);
   }
 
   return finalOptions;


### PR DESCRIPTION
**Describe the bug**
When you try to run `npx test-storybook TestName` in order to run tests on a specific file - you get the following error:
```
TypeError: rawArgv2.replace is not a function
    at <anonymous> (node_modules/@storybook/test-runner/node_modules/jest-cli/build/cli/index.js:188:40)
    at Array.map (<anonymous>)
    at buildArgv (node_modules/@storybook/test-runner/node_modules/jest-cli/build/cli/index.js:188:17)
    at Object.run (node_modules/@storybook/test-runner/node_modules/jest-cli/build/cli/index.js:147:18)
    at async executeJestPlaywright (node_modules/@storybook/test-runner/dist/test-storybook.js:128:3)
    at async main (node_modules/@storybook/test-runner/dist/test-storybook.js:272:3)
```

**Expected behavior**
Specified test file is executed.