### PR TITLE
Fix empty coverage report

### DIFF
--- a/src/test-storybook.ts
+++ b/src/test-storybook.ts
@@ -80,7 +80,7 @@ async function reportCoverage() {
 
 const onProcessEnd = () => {
   cleanup();
-  if (process.env.STORYBOOK_COLLECT_COVERAGE !== 'true') {
+  if (process.env.STORYBOOK_COLLECT_COVERAGE === 'true' && process.env.JEST_SHARD !== 'true') {
     reportCoverage();
   }
 };


### PR DESCRIPTION
Fixes: #313 
This pull request introduces a code change aimed at resolving the issue of an empty coverage report in the project. The previous code checked whether the STORYBOOK_COLLECT_COVERAGE environment variable was not equal to 'true' before calling the reportCoverage() function. However, this approach did not cover all necessary conditions to ensure an accurate coverage report.

The new code includes an additional check to verify that both the STORYBOOK_COLLECT_COVERAGE environment variable is equal to 'true' and the JEST_SHARD environment variable is not equal to 'true'. This ensures that coverage reporting occurs only when both conditions are met, providing a more accurate assessment of test coverage.

By adding the process.env.JEST_SHARD !== 'true' condition, we prevent coverage reporting during Jest sharding, which helps prevent conflicts and inaccuracies in the coverage data.