### PR TITLE
maintenance: remove no-manager-cache flag in example storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build:watch": "tsup --watch",
     "test": "jest",
     "storybook": "storybook dev -p 6006",
-    "start": "concurrently \"yarn build:watch\" \"yarn storybook -- --no-manager-cache --quiet\"",
+    "start": "concurrently \"yarn build:watch\" \"yarn storybook -- --quiet\"",
     "build-storybook": "storybook build",
     "release": "yarn build && auto shipit",
     "test-storybook": "node dist/test-storybook",


### PR DESCRIPTION
## Description

This PR removes `--no-manager-cache` flag from `yarn start` command.

## Background

 The following error occurred when I ran `yarn start`.

```
yarn start
yarn run v1.22.19
$ concurrently "yarn build:watch" "yarn storybook -- --no-manager-cache --quiet"
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
$ storybook dev -p 6006 --no-manager-cache --quiet
$ tsup --watch
[0] CLI Building entry: ./src/index.ts, ./src/setup-page.ts, ./src/test-storybook.ts, ./src/config/jest-playwright.ts, ./src/csf/transformCsf.ts, ./src/playwright/hooks.ts, ./src/playwright/index.ts, ./src/playwright/transformPlaywright.ts, ./src/playwright/transformPlaywrightJson.ts, ./src/util/getCliOptions.ts, ./src/util/getParsedCliOptions.ts, ./src/util/getStorybookMain.ts, ./src/util/getStorybookMetadata.ts, ./src/util/getTestRunnerConfig.ts, ./src/util/index.ts
[0] CLI Using tsconfig: tsconfig.json
[0] CLI tsup v6.7.0
[0] CLI Using tsup config: /Users/mh4gf/ghq/github.com/storybookjs/test-runner/tsup.config.ts
[0] CLI Running in watch mode
[0] CLI Target: es2020
[0] CLI Cleaning output folder
[0] CJS Build start
[0] ESM Build start
[0] CJS dist/setup-page.js                         13.51 KB
[0] CJS dist/index.js                              1.37 KB
[0] CJS dist/playwright/hooks.js                   1.64 KB
[0] CJS dist/playwright/transformPlaywright.js     4.64 KB
[0] CJS dist/util/getStorybookMain.js              3.13 KB
[0] CJS dist/playwright/transformPlaywrightJson.js 4.35 KB
[0] CJS dist/csf/transformCsf.js                   4.82 KB
[0] CJS dist/util/getCliOptions.js                 2.24 KB
[0] CJS dist/util/index.js                         1.48 KB
[0] CJS dist/util/getStorybookMetadata.js          2.16 KB
[0] CJS dist/playwright/index.js                   1.51 KB
[0] CJS dist/util/getTestRunnerConfig.js           1.63 KB
[0] CJS dist/util/getParsedCliOptions.js           4.23 KB
[0] CJS dist/config/jest-playwright.js             4.47 KB
[0] CJS dist/test-storybook.js                     10.86 KB
[0] CJS ⚡️ Build success in 26ms
[0] ESM dist/setup-page.mjs                         11.93 KB
[0] ESM dist/index.mjs                              152.00 B
[0] ESM dist/csf/transformCsf.mjs                   3.15 KB
[0] ESM dist/playwright/hooks.mjs                   642.00 B
[0] ESM dist/test-storybook.mjs                     8.95 KB
[0] ESM dist/playwright/transformPlaywright.mjs     2.87 KB
[0] ESM dist/playwright/index.mjs                   549.00 B
[0] ESM dist/playwright/transformPlaywrightJson.mjs 2.65 KB
[0] ESM dist/util/getParsedCliOptions.mjs           3.13 KB
[0] ESM dist/util/getStorybookMetadata.mjs          1.08 KB
[0] ESM dist/config/jest-playwright.mjs             2.72 KB
[0] ESM dist/util/getStorybookMain.mjs              1.42 KB
[0] ESM dist/util/getTestRunnerConfig.mjs           599.00 B
[0] ESM dist/util/getCliOptions.mjs                 1.24 KB
[0] ESM dist/util/index.mjs                         187.00 B
[0] ESM ⚡️ Build success in 26ms
[0] CLI Watching for changes in "."
[0] CLI Ignoring changes in "**/{.git,node_modules}/**" | "dist"
[0] DTS Build start
[1] error: unknown option '--no-manager-cache'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[1] yarn storybook -- --no-manager-cache --quiet exited with code 1
[0] DTS ⚡️ Build success in 3338ms
```

The `--no-manager-cache` option is not found.

This option has been removed in this issue: https://github.com/storybookjs/storybook/issues/20884
I have not been able to find a direct reason why it was removed, but this comment https://github.com/storybookjs/storybook/issues/19027#issuecomment-1583945292 indicates that it is no longer cached from v7.