### PR TITLE
chore: set `engines.node` to `>=12.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,9 @@
     "tempy": "^1.0.1",
     "ts-dedent": "^2.0.0"
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "auto": {
     "prereleaseBranches": [
       "next",


### PR DESCRIPTION
This indicates currently working Node.js versions.

Below error on Node.js v10:

```
$ yarn
internal/modules/cjs/loader.js:638
    throw err;
    ^

Error: Cannot find module 'worker_threads'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at /app/.yarn/releases/yarn-3.6.3.cjs:423:3061
    at Object.<anonymous> (/app/.yarn/releases/yarn-3.6.3.cjs:744:8770)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)

```