### PR TITLE
BREAKING: Bump minimum Node.js version to ^14.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "ts-dedent": "^2.0.0"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
   },
   "auto": {
     "prereleaseBranches": [


### PR DESCRIPTION
This tentatively aligns `node.engines` with that of Jest 29, except without v19.

#### Related:
- #353 

#### Blocking:
- #348

#### Blocked by
- [ ] Release of #349 