### PR TITLE
fix: Make tags optional in TestRunnerConfig

### DIFF
--- a/src/playwright/hooks.ts
+++ b/src/playwright/hooks.ts
@@ -34,10 +34,10 @@ export interface TestRunnerConfig {
   /**
    * Tags to include, exclude, or skip. These tags are defined as annotations in your story or meta.
    */
-  tags: {
-    include: string[];
-    exclude: string[];
-    skip: string[];
+  tags?: {
+    include?: string[];
+    exclude?: string[];
+    skip?: string[];
   };
 }
 


### PR DESCRIPTION
The new `tags` option in the `TestRunnerConfig` is currently required and each property is also required. This results in the developer having to include all of it, even when not used.

```js
{
	tags: {
		include: [],
		exclude: [],
		skip: [],
	},
},
```

This PR makes it optional and does not require all properties, allowing for only used properties to be defined.

```js
{
	tags: {
		exclude: ['design'],
	},
},
```