### PR TITLE
Bump `jest-playwright-preset` from `v3.0.1` to `v4.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "jest-circus": "^29.6.4",
     "jest-environment-node": "^29.6.4",
     "jest-junit": "^16.0.0",
-    "jest-playwright-preset": "^3.0.1",
+    "jest-playwright-preset": "^4.0.0",
     "jest-runner": "^29.6.4",
     "jest-serializer-html": "^7.1.0",
     "jest-watch-typeahead": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4329,7 +4329,7 @@ __metadata:
     jest-environment-node: ^29.6.4
     jest-image-snapshot: ^6.2.0
     jest-junit: ^16.0.0
-    jest-playwright-preset: ^3.0.1
+    jest-playwright-preset: ^4.0.0
     jest-runner: ^29.6.4
     jest-serializer-html: ^7.1.0
     jest-watch-typeahead: ^2.0.0
@@ -5584,15 +5584,6 @@ __metadata:
   version: 3.0.0
   resolution: "await-to-js@npm:3.0.0"
   checksum: b6e9dcf9f0990312d2ae28fcfa0a2c2d1ba48baaa161591fba61d3accf97072ce8a7187ee4e889f3148e1707a7ed1d174b9dd04ce4f79f02d7f8c9e017e90f8e
-  languageName: node
-  linkType: hard
-
-"axios@npm:^0.21.1":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
-  dependencies:
-    follow-redirects: ^1.14.0
-  checksum: 44245f24ac971e7458f3120c92f9d66d1fc695e8b97019139de5b0cc65d9b8104647db01e5f46917728edfc0cfd88eb30fc4c55e6053eef4ace76768ce95ff3c
   languageName: node
   linkType: hard
 
@@ -7825,7 +7816,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.0":
+"follow-redirects@npm:^1.15.0":
   version: 1.15.3
   resolution: "follow-redirects@npm:1.15.3"
   peerDependenciesMeta:
@@ -9489,12 +9480,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-playwright-preset@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "jest-playwright-preset@npm:3.0.1"
+"jest-playwright-preset@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jest-playwright-preset@npm:4.0.0"
   dependencies:
     expect-playwright: ^0.8.0
-    jest-process-manager: ^0.3.1
+    jest-process-manager: ^0.4.0
     nyc: ^15.1.0
     playwright-core: ">=1.2.0"
     rimraf: ^3.0.2
@@ -9504,7 +9495,7 @@ __metadata:
     jest-circus: ^29.3.1
     jest-environment-node: ^29.3.1
     jest-runner: ^29.3.1
-  checksum: 2ee504fce5b72fef847c3bbfc74627c602fa07257828cc2572c19a172409d2d1ef6a2a02f08f107f5ac298e420f689371b0b0d939629ca9ee34ccb45557befd1
+  checksum: bd59c166114c243c1e1506d5a6a11b583e280d0b6a8004022951b816919cd0aff45702ad802c966ea9dac722ddf6ad94e4c7d17cfbeb1fb657ac14053a24d47d
   languageName: node
   linkType: hard
 
@@ -9520,9 +9511,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-process-manager@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "jest-process-manager@npm:0.3.1"
+"jest-process-manager@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "jest-process-manager@npm:0.4.0"
   dependencies:
     "@types/wait-on": ^5.2.0
     chalk: ^4.1.0
@@ -9533,8 +9524,8 @@ __metadata:
     signal-exit: ^3.0.3
     spawnd: ^5.0.0
     tree-kill: ^1.2.2
-    wait-on: ^5.3.0
-  checksum: b71a0412c747d75341672a3ac42bb529232011039562b839cc73704debccf5aaf0e8a4db3a91ad05a819247f3191de905d2e7a1df7299eb895a28733a041f9d7
+    wait-on: ^7.0.0
+  checksum: 7c31a2d08eeb801c8a9a29c4b129a173527472f167d2c7d4cda104bc9d711fb08919de0a96ba37a1564172bcec2219c41d9fc748900b1e1eb5f9e1736c23850b
   languageName: node
   linkType: hard
 
@@ -9760,7 +9751,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"joi@npm:^17.11.0, joi@npm:^17.3.0":
+"joi@npm:^17.11.0":
   version: 17.11.0
   resolution: "joi@npm:17.11.0"
   dependencies:
@@ -12251,15 +12242,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^6.6.3":
-  version: 6.6.7
-  resolution: "rxjs@npm:6.6.7"
-  dependencies:
-    tslib: ^1.9.0
-  checksum: bc334edef1bb8bbf56590b0b25734ba0deaf8825b703256a93714308ea36dff8a11d25533671adf8e104e5e8f256aa6fdfe39b2e248cdbd7a5f90c260acbbd1b
-  languageName: node
-  linkType: hard
-
 "rxjs@npm:^7.0.0, rxjs@npm:^7.8.1":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
@@ -13306,7 +13288,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.13.0, tslib@npm:^1.9.0":
+"tslib@npm:^1.13.0":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -13835,22 +13817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wait-on@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "wait-on@npm:5.3.0"
-  dependencies:
-    axios: ^0.21.1
-    joi: ^17.3.0
-    lodash: ^4.17.21
-    minimist: ^1.2.5
-    rxjs: ^6.6.3
-  bin:
-    wait-on: bin/wait-on
-  checksum: b7099104b7900ff6349f1196edff759076ab557a2053c017a587819f7a59f146ec9e35c99579acd31dcda371bfa72241ef28b8ccda902f0bf3fbf2d780a00ebf
-  languageName: node
-  linkType: hard
-
-"wait-on@npm:^7.2.0":
+"wait-on@npm:^7.0.0, wait-on@npm:^7.2.0":
   version: 7.2.0
   resolution: "wait-on@npm:7.2.0"
   dependencies:


### PR DESCRIPTION
fixes #386

This PR proposes to bump `jest-playwright-preset` package from `v3.0.1` to `v4.0.0` in order to fix the moderate vulnerability stemming Axios reported by Dependabot.

[jest-playwright-preset@v4.0.0 Release note](https://github.com/playwright-community/jest-playwright/releases/tag/v4.0.0)