### PR TITLE
Filter duplicated error messages in browser logs

### DIFF
--- a/src/setup-page-script.ts
+++ b/src/setup-page-script.ts
@@ -197,8 +197,10 @@ class StorybookTestRunnerError extends Error {
     const storyUrl = `${storybookUrl}?path=/story/${storyId}`;
     const finalStoryUrl = `${storyUrl}&addonPanel=storybook/interactions/panel`;
     const separator = '\n\n--------------------------------------------------';
+    // The original error message will also be collected in the logs, so we filter it to avoid duplication
+    const finalLogs = logs.filter((err) => !err.includes(errorMessage));
     const extraLogs =
-      logs.length > 0 ? separator + '\n\nBrowser logs:\n\n' + logs.join('\n\n') : '';
+      finalLogs.length > 0 ? separator + '\n\nBrowser logs:\n\n' + finalLogs.join('\n\n') : '';
 
     this.message = `\nAn error occurred in the following story. Access the link for full output:\n${finalStoryUrl}\n\nMessage:\n ${truncate(
       errorMessage,


### PR DESCRIPTION
Before:
![image](https://github.com/storybookjs/test-runner/assets/1671563/cf04ee7a-a199-4e04-a7fd-e4d02d4d157a)

After:
![image](https://github.com/storybookjs/test-runner/assets/1671563/df4c051e-742b-4d22-b440-14a5c6c1e414)
