### PR TITLE
Introduce logLevel configuration

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -7,6 +7,7 @@ const customSnapshotsDir = `${process.cwd()}/${snapshotsDir}`;
 const skipSnapshots = process.env.SKIP_SNAPSHOTS === 'true';
 
 const config: TestRunnerConfig = {
+  logLevel: 'verbose',
   tags: {
     exclude: ['exclude'],
     include: [],

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Storybook test runner turns all of your stories into executable tests.
   - [prepare](#prepare)
   - [getHttpHeaders](#gethttpheaders)
   - [tags (experimental)](#tags-experimental)
+  - [logLevel](#loglevel)
   - [Utility functions](#utility-functions)
     - [getStoryContext](#getstorycontext)
     - [waitForPageReady](#waitforpageready)
@@ -704,6 +705,26 @@ export default config;
 ```
 
 `tags` are used for filtering your tests. Learn more [here](#filtering-tests-experimental).
+
+#### logLevel
+
+When tests fail and there were browser logs during the rendering of a story, the test-runner provides the logs alongside the error message. The `logLevel` property defines what kind of logs should be displayed:
+
+- **`info` (default):** Shows console logs, warnings, and errors.
+- **`warn`:** Shows only warnings and errors.
+- **`error`:** Displays only error messages.
+- **`verbose`:** Includes all console outputs, including debug information and stack traces.
+- **`none`:** Suppresses all log output.
+
+```ts
+// .storybook/test-runner.ts
+import type { TestRunnerConfig } from '@storybook/test-runner';
+
+const config: TestRunnerConfig = {
+  logLevel: 'verbose',
+};
+export default config;
+```
 
 ### Utility functions
 

--- a/src/playwright/hooks.ts
+++ b/src/playwright/hooks.ts
@@ -58,6 +58,11 @@ export interface TestRunnerConfig {
     exclude?: string[];
     skip?: string[];
   };
+  /**
+   * Defines the log level of the test runner. Browser logs are printed to the console when reporting errors.
+   * @default 'info'
+   */
+  logLevel?: 'info' | 'warn' | 'error' | 'verbose' | 'none';
 }
 
 export const setPreVisit = (preVisit: TestHook) => {

--- a/src/setup-page.ts
+++ b/src/setup-page.ts
@@ -69,6 +69,7 @@ export const setupPage = async (page: Page, browserContext: BrowserContext) => {
     .replaceAll('{{failOnConsole}}', failOnConsole ?? 'false')
     .replaceAll('{{renderedEvent}}', renderedEvent)
     .replaceAll('{{testRunnerVersion}}', testRunnerVersion)
+    .replaceAll('{{logLevel}}', testRunnerConfig.logLevel ?? 'info')
     .replaceAll('{{debugPrintLimit}}', debugPrintLimit.toString());
 
   await page.addScriptTag({ content });


### PR DESCRIPTION
This PR adds a feature to tweak with logLevels in the test-runner.

As part of this work, the following methods are also collected (in verbose log level): `info, table, dir, debug`

#### logLevel

When tests fail and there were browser logs during the rendering of a story, the test-runner provides the logs alongside the error message. The `logLevel` property defines what kind of logs should be displayed:

- **`info` (default):** Shows console logs, warnings, and errors.
- **`warn`:** Shows only warnings and errors.
- **`error`:** Displays only error messages.
- **`verbose`:** Includes all console outputs, including debug information and stack traces.
- **`none`:** Suppresses all log output.

```ts
// .storybook/test-runner.ts
import type { TestRunnerConfig } from '@storybook/test-runner';

const config: TestRunnerConfig = {
  logLevel: 'verbose',
};
export default config;
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.16.0--canary.406.dd7eb64.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.16.0--canary.406.dd7eb64.0
  # or 
  yarn add @storybook/test-runner@0.16.0--canary.406.dd7eb64.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
