### PR TITLE
Support stories with meta id for permalinking

### DIFF
--- a/src/csf/transformCsf.ts
+++ b/src/csf/transformCsf.ts
@@ -28,13 +28,23 @@ export interface TransformOptions {
   skipTags?: string[];
 }
 
-export const prefixFunction = (key: string, title: string, testPrefixer: TestPrefixer) => {
+export const prefixFunction = ({
+  key,
+  testPrefixer,
+  title,
+  id,
+}: {
+  key: string;
+  title: string;
+  testPrefixer: TestPrefixer;
+  id?: string;
+}) => {
   const name = storyNameFromExport(key);
   const context: TestContext = {
     storyExport: t.identifier(key),
     name: t.stringLiteral(name), // FIXME .name annotation
     title: t.stringLiteral(title),
-    id: t.stringLiteral(toId(title, name)),
+    id: t.stringLiteral(id ? toId(id, name) : toId(title, name)),
   };
 
   const result = makeArray(testPrefixer(context));
@@ -46,11 +56,13 @@ const makePlayTest = ({
   key,
   metaOrStoryPlay,
   title,
+  id,
   testPrefix,
   shouldSkip,
 }: {
   key: string;
   title: string;
+  id?: string;
   metaOrStoryPlay?: boolean;
   testPrefix: TestPrefixer;
   shouldSkip?: boolean;
@@ -59,7 +71,7 @@ const makePlayTest = ({
     t.expressionStatement(
       t.callExpression(shouldSkip ? t.identifier('it.skip') : t.identifier('it'), [
         t.stringLiteral(metaOrStoryPlay ? 'play-test' : 'smoke-test'),
-        prefixFunction(key, title, testPrefix),
+        prefixFunction({ key, title, testPrefixer: testPrefix, id }),
       ])
     ),
   ];
@@ -141,6 +153,7 @@ export const transformCsf = (
           ...makePlayTest({
             key,
             title,
+            id: csf.meta.id,
             metaOrStoryPlay: !!storyAnnotations[key]?.play,
             testPrefix: testPrefixer,
             shouldSkip,

--- a/src/csf/transformCsf.ts
+++ b/src/csf/transformCsf.ts
@@ -44,7 +44,7 @@ export const prefixFunction = ({
     storyExport: t.identifier(key),
     name: t.stringLiteral(name), // FIXME .name annotation
     title: t.stringLiteral(title),
-    id: t.stringLiteral(id ? toId(id, name) : toId(title, name)),
+    id: t.stringLiteral(toId(id ?? title, name)),
   };
 
   const result = makeArray(testPrefixer(context));


### PR DESCRIPTION
This PR adds support for the use of ID in stories which we are used for permalinking, e.g.

```ts
export default {
    title: 'Components/Notifications/In-page Alerts',
    component: InPageAlert,
    id: 'in-page-alerts',
}
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.16.1--canary.419.49762ec.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.16.1--canary.419.49762ec.0
  # or 
  yarn add @storybook/test-runner@0.16.1--canary.419.49762ec.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
