### PR TITLE
Remove --prerelease from sb upgrade CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upgrade to storybook@next
         run: |
-          npx storybook@next upgrade --prerelease --yes
+          npx storybook@next upgrade --yes
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 


### PR DESCRIPTION
Works on https://github.com/storybookjs/storybook/issues/25293
Depends on https://github.com/storybookjs/storybook/pull/25553 getting released by https://github.com/storybookjs/storybook/pull/25546

The `--prerelease` flag has been removed from the `upgrade` command in SB 8.