### PR TITLE
Fix 8.1.4+ support for v5 index.json

### DIFF
--- a/src/playwright/transformPlaywrightJson.ts
+++ b/src/playwright/transformPlaywrightJson.ts
@@ -94,7 +94,7 @@ function v3TitleMapToV4TitleMap(titleIdToStories: Record<string, V3Story[]>) {
           ({
             type: isV3DocsOnly(stories) ? 'docs' : 'story',
             ...story,
-          } satisfies V4Entry)
+          }) satisfies V4Entry
       ),
     ])
   );
@@ -120,7 +120,7 @@ export const transformPlaywrightJson = (index: V3StoriesIndex | V4Index | Unsupp
       Object.values((index as V3StoriesIndex).stories)
     );
     titleIdToEntries = v3TitleMapToV4TitleMap(titleIdToStories);
-  } else if (index.v === 4) {
+  } else if (index.v === 4 || index.v === 5) {
     // TODO: Once Storybook 8.0 is released, we should only support v4 and higher
     titleIdToEntries = groupByTitleId<V4Entry>(Object.values((index as V4Index).entries));
   } else {

--- a/src/playwright/transformPlaywrightJson.ts
+++ b/src/playwright/transformPlaywrightJson.ts
@@ -120,6 +120,7 @@ export const transformPlaywrightJson = (index: V3StoriesIndex | V4Index | Unsupp
       Object.values((index as V3StoriesIndex).stories)
     );
     titleIdToEntries = v3TitleMapToV4TitleMap(titleIdToStories);
+  // v4 and v5 are pretty much similar, so we process it in the same way
   } else if (index.v === 4 || index.v === 5) {
     // TODO: Once Storybook 8.0 is released, we should only support v4 and higher
     titleIdToEntries = groupByTitleId<V4Entry>(Object.values((index as V4Index).entries));


### PR DESCRIPTION
Closes https://github.com/storybookjs/test-runner/issues/472

## What I did

Include support for v5 which is identical to v4 in every meaningful way

## Checklist for Contributors

#### Manual testing

Run the test-runner in `index.json` mode against an 8.1.4+ Storybook
