### PR TITLE
Fix: Combine tags correctly when transforming story files

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,3 +1,4 @@
+import type { Preview } from '@storybook/react';
 import { isTestRunner } from './is-test-runner';
 
 const withSkippableTests = (StoryFn, { parameters }) => {
@@ -8,4 +9,9 @@ const withSkippableTests = (StoryFn, { parameters }) => {
   return StoryFn();
 };
 
-export const decorators = [withSkippableTests];
+const preview: Preview = {
+  tags: ['global-tag'],
+  decorators: [withSkippableTests],
+};
+
+export default preview;

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ module.exports = {
 
 ## Filtering tests (experimental)
 
-You might want to skip certain stories in the test-runner, run tests only against a subset of stories, or exclude certain stories entirely from your tests. This is possible via the `tags` annotation.
+You might want to skip certain stories in the test-runner, run tests only against a subset of stories, or exclude certain stories entirely from your tests. This is possible via the `tags` annotation. By default, the test-runner includes every story with the `"test"` tag. This tag is included by default in Storybook 8 for all stories, unless the user tells otherwise via [tag negation](https://storybook.js.org/docs/writing-stories/tags#removing-tags).
 
 This annotation can be part of a story, therefore only applying to it, or the component meta (the default export), which applies to all stories in the file:
 

--- a/src/csf/transformCsf.ts
+++ b/src/csf/transformCsf.ts
@@ -2,7 +2,7 @@
 import { loadCsf } from '@storybook/csf-tools';
 import * as t from '@babel/types';
 import generate from '@babel/generator';
-import { toId, storyNameFromExport } from '@storybook/csf';
+import { toId, storyNameFromExport, combineTags } from '@storybook/csf';
 import dedent from 'ts-dedent';
 
 import { getTagOptions } from '../util/getTagOptions';
@@ -126,7 +126,13 @@ export const transformCsf = (
         acc[key].play = annotations.play;
       }
 
-      acc[key].tags = csf._stories[key].tags || csf.meta?.tags || [];
+      acc[key].tags = combineTags(
+        'test',
+        'dev',
+        ...(csf.meta?.tags || []),
+        ...(csf._stories[key].tags || [])
+      );
+
       return acc;
     },
     {}

--- a/src/csf/transformCsf.ts
+++ b/src/csf/transformCsf.ts
@@ -108,7 +108,8 @@ export const transformCsf = (
     beforeEachPrefixer,
     insertTestIfEmpty,
     makeTitle,
-  }: TransformOptions
+    previewAnnotations = { tags: [] },
+  }: TransformOptions & { previewAnnotations?: Record<string, any> }
 ) => {
   const { includeTags, excludeTags, skipTags } = getTagOptions();
 
@@ -130,7 +131,8 @@ export const transformCsf = (
         'test',
         'dev',
         ...(csf.meta?.tags || []),
-        ...(csf._stories[key].tags || [])
+        ...(csf._stories[key].tags || []),
+        ...previewAnnotations.tags
       );
 
       return acc;

--- a/src/csf/transformCsf.ts
+++ b/src/csf/transformCsf.ts
@@ -130,9 +130,9 @@ export const transformCsf = (
       acc[key].tags = combineTags(
         'test',
         'dev',
+        ...previewAnnotations.tags,
         ...(csf.meta?.tags || []),
-        ...(csf._stories[key].tags || []),
-        ...previewAnnotations.tags
+        ...(csf._stories[key].tags || [])
       );
 
       return acc;

--- a/src/playwright/transformPlaywright.test.ts
+++ b/src/playwright/transformPlaywright.test.ts
@@ -535,6 +535,137 @@ describe('Playwright', () => {
         }
       `);
     });
+    it('should work with tag negation', () => {
+      process.env.STORYBOOK_INCLUDE_TAGS = 'play';
+      // Should result in:
+      // - A being included
+      // - B being excluded
+      expect(
+        transformPlaywright(
+          dedent`
+        export default { title: 'foo/bar', component: Button, tags: ['play'] };
+        export const A = { };
+        export const B = { tags: ['!play']  };
+      `,
+          filename
+        )
+      ).toMatchInlineSnapshot(`
+        if (!require.main) {
+          describe("Example/foo/bar", () => {
+            describe("A", () => {
+              it("smoke-test", async () => {
+                const testFn = async () => {
+                  const context = {
+                    id: "example-foo-bar--a",
+                    title: "Example/foo/bar",
+                    name: "A"
+                  };
+                  if (globalThis.__sbPreVisit) {
+                    await globalThis.__sbPreVisit(page, context);
+                  }
+                  const result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-foo-bar--a"
+                  });
+                  if (globalThis.__sbPostVisit) {
+                    await globalThis.__sbPostVisit(page, context);
+                  }
+                  if (globalThis.__sbCollectCoverage) {
+                    const isCoverageSetupCorrectly = await page.evaluate(() => '__coverage__' in window);
+                    if (!isCoverageSetupCorrectly) {
+                      throw new Error(\`[Test runner] An error occurred when evaluating code coverage:
+          The code in this story is not instrumented, which means the coverage setup is likely not correct.
+          More info: https://github.com/storybookjs/test-runner#setting-up-code-coverage\`);
+                    }
+                    await jestPlaywright.saveCoverage(page);
+                  }
+                  return result;
+                };
+                try {
+                  await testFn();
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    console.log(\`An error occurred in the following story, most likely because of a navigation: "\${"Example/foo/bar"}/\${"A"}". Retrying...\`);
+                    await jestPlaywright.resetPage();
+                    await globalThis.__sbSetupPage(globalThis.page, globalThis.context);
+                    await testFn();
+                  } else {
+                    throw err;
+                  }
+                }
+              });
+            });
+          });
+        }
+      `);
+    });
+    it('should include "test" tag by default', () => {
+      // Should result in:
+      // - A being included
+      // - B being excluded
+      expect(
+        transformPlaywright(
+          dedent`
+        export default { title: 'foo/bar', component: Button };
+        export const A = { };
+        export const B = { tags: ['!test']  };
+      `,
+          filename
+        )
+      ).toMatchInlineSnapshot(`
+        if (!require.main) {
+          describe("Example/foo/bar", () => {
+            describe("A", () => {
+              it("smoke-test", async () => {
+                const testFn = async () => {
+                  const context = {
+                    id: "example-foo-bar--a",
+                    title: "Example/foo/bar",
+                    name: "A"
+                  };
+                  if (globalThis.__sbPreVisit) {
+                    await globalThis.__sbPreVisit(page, context);
+                  }
+                  const result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-foo-bar--a"
+                  });
+                  if (globalThis.__sbPostVisit) {
+                    await globalThis.__sbPostVisit(page, context);
+                  }
+                  if (globalThis.__sbCollectCoverage) {
+                    const isCoverageSetupCorrectly = await page.evaluate(() => '__coverage__' in window);
+                    if (!isCoverageSetupCorrectly) {
+                      throw new Error(\`[Test runner] An error occurred when evaluating code coverage:
+          The code in this story is not instrumented, which means the coverage setup is likely not correct.
+          More info: https://github.com/storybookjs/test-runner#setting-up-code-coverage\`);
+                    }
+                    await jestPlaywright.saveCoverage(page);
+                  }
+                  return result;
+                };
+                try {
+                  await testFn();
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    console.log(\`An error occurred in the following story, most likely because of a navigation: "\${"Example/foo/bar"}/\${"A"}". Retrying...\`);
+                    await jestPlaywright.resetPage();
+                    await globalThis.__sbSetupPage(globalThis.page, globalThis.context);
+                    await testFn();
+                  } else {
+                    throw err;
+                  }
+                }
+              });
+            });
+          });
+        }
+      `);
+    });
     it('should no op when includeTags is passed but not matched', () => {
       process.env.STORYBOOK_INCLUDE_TAGS = 'play';
       expect(

--- a/src/playwright/transformPlaywright.test.ts
+++ b/src/playwright/transformPlaywright.test.ts
@@ -42,6 +42,7 @@ describe('Playwright', () => {
     delete process.env.STORYBOOK_INCLUDE_TAGS;
     delete process.env.STORYBOOK_EXCLUDE_TAGS;
     delete process.env.STORYBOOK_SKIP_TAGS;
+    delete process.env.STORYBOOK_PREVIEW_TAGS;
   });
 
   describe('tag filtering mechanism', () => {
@@ -324,14 +325,17 @@ describe('Playwright', () => {
       `);
     });
     it('should work in conjunction with includeTags, excludeTags and skipTags', () => {
-      process.env.STORYBOOK_INCLUDE_TAGS = 'play,design';
+      process.env.STORYBOOK_INCLUDE_TAGS = 'play,design,global-tag';
       process.env.STORYBOOK_SKIP_TAGS = 'skip';
       process.env.STORYBOOK_EXCLUDE_TAGS = 'exclude';
+      process.env.STORYBOOK_PREVIEW_TAGS = 'global-tag';
+
       // Should result in:
       // - A being excluded
       // - B being included, but skipped
       // - C being included
-      // - D being excluded
+      // - D being included
+      // - E being excluded
       expect(
         transformPlaywright(
           dedent`
@@ -339,7 +343,8 @@ describe('Playwright', () => {
         export const A = { tags: ['play', 'exclude'] };
         export const B = { tags: ['play', 'skip'] };
         export const C = { tags: ['design'] };
-        export const D = { };
+        export const D = { tags: ['global-tag'] };
+        export const E = { };
       `,
           filename
         )
@@ -427,6 +432,96 @@ describe('Playwright', () => {
                 } catch (err) {
                   if (err.toString().includes('Execution context was destroyed')) {
                     console.log(\`An error occurred in the following story, most likely because of a navigation: "\${"Example/foo/bar"}/\${"C"}". Retrying...\`);
+                    await jestPlaywright.resetPage();
+                    await globalThis.__sbSetupPage(globalThis.page, globalThis.context);
+                    await testFn();
+                  } else {
+                    throw err;
+                  }
+                }
+              });
+            });
+            describe("D", () => {
+              it("smoke-test", async () => {
+                const testFn = async () => {
+                  const context = {
+                    id: "example-foo-bar--d",
+                    title: "Example/foo/bar",
+                    name: "D"
+                  };
+                  if (globalThis.__sbPreVisit) {
+                    await globalThis.__sbPreVisit(page, context);
+                  }
+                  const result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-foo-bar--d"
+                  });
+                  if (globalThis.__sbPostVisit) {
+                    await globalThis.__sbPostVisit(page, context);
+                  }
+                  if (globalThis.__sbCollectCoverage) {
+                    const isCoverageSetupCorrectly = await page.evaluate(() => '__coverage__' in window);
+                    if (!isCoverageSetupCorrectly) {
+                      throw new Error(\`[Test runner] An error occurred when evaluating code coverage:
+          The code in this story is not instrumented, which means the coverage setup is likely not correct.
+          More info: https://github.com/storybookjs/test-runner#setting-up-code-coverage\`);
+                    }
+                    await jestPlaywright.saveCoverage(page);
+                  }
+                  return result;
+                };
+                try {
+                  await testFn();
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    console.log(\`An error occurred in the following story, most likely because of a navigation: "\${"Example/foo/bar"}/\${"D"}". Retrying...\`);
+                    await jestPlaywright.resetPage();
+                    await globalThis.__sbSetupPage(globalThis.page, globalThis.context);
+                    await testFn();
+                  } else {
+                    throw err;
+                  }
+                }
+              });
+            });
+            describe("E", () => {
+              it("smoke-test", async () => {
+                const testFn = async () => {
+                  const context = {
+                    id: "example-foo-bar--e",
+                    title: "Example/foo/bar",
+                    name: "E"
+                  };
+                  if (globalThis.__sbPreVisit) {
+                    await globalThis.__sbPreVisit(page, context);
+                  }
+                  const result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-foo-bar--e"
+                  });
+                  if (globalThis.__sbPostVisit) {
+                    await globalThis.__sbPostVisit(page, context);
+                  }
+                  if (globalThis.__sbCollectCoverage) {
+                    const isCoverageSetupCorrectly = await page.evaluate(() => '__coverage__' in window);
+                    if (!isCoverageSetupCorrectly) {
+                      throw new Error(\`[Test runner] An error occurred when evaluating code coverage:
+          The code in this story is not instrumented, which means the coverage setup is likely not correct.
+          More info: https://github.com/storybookjs/test-runner#setting-up-code-coverage\`);
+                    }
+                    await jestPlaywright.saveCoverage(page);
+                  }
+                  return result;
+                };
+                try {
+                  await testFn();
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    console.log(\`An error occurred in the following story, most likely because of a navigation: "\${"Example/foo/bar"}/\${"E"}". Retrying...\`);
                     await jestPlaywright.resetPage();
                     await globalThis.__sbSetupPage(globalThis.page, globalThis.context);
                     await testFn();

--- a/src/playwright/transformPlaywright.ts
+++ b/src/playwright/transformPlaywright.ts
@@ -75,11 +75,13 @@ const makeTitleFactory = (filename: string) => {
 };
 
 export const transformPlaywright = (src: string, filename: string) => {
+  const tags = process.env.STORYBOOK_PREVIEW_TAGS?.split(',') ?? [];
   const transformOptions = {
     testPrefixer,
     insertTestIfEmpty: true,
     clearBody: true,
     makeTitle: makeTitleFactory(filename),
+    previewAnnotations: { tags },
   };
 
   const result = transformCsf(src, transformOptions);

--- a/src/playwright/transformPlaywrightJson.test.ts
+++ b/src/playwright/transformPlaywrightJson.test.ts
@@ -25,17 +25,19 @@ describe('Playwright Json', () => {
             id: 'example-header--logged-in',
             title: 'Example/Header',
             name: 'Logged In',
-            tags: ['play-fn'],
+            tags: ['test', 'play-fn'],
           },
           'example-header--logged-out': {
             id: 'example-header--logged-out',
             title: 'Example/Header',
             name: 'Logged Out',
+            tags: ['test'],
           },
           'example-page--logged-in': {
             id: 'example-page--logged-in',
             title: 'Example/Page',
             name: 'Logged In',
+            tags: ['test'],
           },
         },
       } satisfies V4Index;
@@ -592,6 +594,76 @@ describe('Playwright Json', () => {
               fileName: './stories/basic/Introduction.stories.mdx',
             },
           },
+          'example-page--logged-in': {
+            id: 'example-page--logged-in',
+            title: 'Example/Page',
+            name: 'Logged In',
+            parameters: {
+              __id: 'example-page--logged-in',
+              docsOnly: false,
+              fileName: './stories/basic/Page.stories.js',
+            },
+          },
+        },
+      } satisfies V3StoriesIndex;
+      expect(transformPlaywrightJson(input)).toMatchInlineSnapshot(`
+        {
+          "example-page": "describe("Example/Page", () => {
+          describe("Logged In", () => {
+            it("smoke-test", async () => {
+              const testFn = async () => {
+                const context = {
+                  id: "example-page--logged-in",
+                  title: "Example/Page",
+                  name: "Logged In"
+                };
+                if (globalThis.__sbPreVisit) {
+                  await globalThis.__sbPreVisit(page, context);
+                }
+                const result = await page.evaluate(({
+                  id,
+                  hasPlayFn
+                }) => __test(id, hasPlayFn), {
+                  id: "example-page--logged-in"
+                });
+                if (globalThis.__sbPostVisit) {
+                  await globalThis.__sbPostVisit(page, context);
+                }
+                if (globalThis.__sbCollectCoverage) {
+                  const isCoverageSetupCorrectly = await page.evaluate(() => '__coverage__' in window);
+                  if (!isCoverageSetupCorrectly) {
+                    throw new Error(\`[Test runner] An error occurred when evaluating code coverage:
+        The code in this story is not instrumented, which means the coverage setup is likely not correct.
+        More info: https://github.com/storybookjs/test-runner#setting-up-code-coverage\`);
+                  }
+                  await jestPlaywright.saveCoverage(page);
+                }
+                return result;
+              };
+              try {
+                await testFn();
+              } catch (err) {
+                if (err.toString().includes('Execution context was destroyed')) {
+                  console.log(\`An error occurred in the following story, most likely because of a navigation: "\${"Example/Page"}/\${"Logged In"}". Retrying...\`);
+                  await jestPlaywright.resetPage();
+                  await globalThis.__sbSetupPage(globalThis.page, globalThis.context);
+                  await testFn();
+                } else {
+                  throw err;
+                }
+              }
+            });
+          });
+        });",
+        }
+      `);
+    });
+
+    it('should include "test" tag by default', () => {
+      process.env.STORYBOOK_INCLUDE_TAGS = 'test';
+      const input = {
+        v: 3,
+        stories: {
           'example-page--logged-in': {
             id: 'example-page--logged-in',
             title: 'Example/Page',

--- a/src/playwright/transformPlaywrightJson.ts
+++ b/src/playwright/transformPlaywrightJson.ts
@@ -59,6 +59,11 @@ export const makeDescribe = (title: string, stmts: t.Statement[]) => {
   );
 };
 
+type V3Story = Omit<V4Entry, 'type'> & { parameters?: StoryParameters };
+export type V3StoriesIndex = {
+  v: 3;
+  stories: Record<StoryId, V3Story>;
+};
 type V4Entry = {
   type?: 'story' | 'docs';
   id: StoryId;
@@ -71,17 +76,18 @@ export type V4Index = {
   entries: Record<StoryId, V4Entry>;
 };
 
+type V5Entry = V4Entry & { tags: string[] };
+export type V5Index = {
+  v: 5;
+  entries: Record<StoryId, V5Entry>;
+};
+
 type StoryParameters = {
   __id: StoryId;
   docsOnly?: boolean;
   fileName?: string;
 };
 
-type V3Story = Omit<V4Entry, 'type'> & { parameters?: StoryParameters };
-export type V3StoriesIndex = {
-  v: 3;
-  stories: Record<StoryId, V3Story>;
-};
 export type UnsupportedVersion = { v: number };
 const isV3DocsOnly = (stories: V3Story[]) => stories.length === 1 && stories[0].name === 'Page';
 
@@ -93,7 +99,28 @@ function v3TitleMapToV4TitleMap(titleIdToStories: Record<string, V3Story[]>) {
         ({ parameters, ...story }) =>
           ({
             type: isV3DocsOnly(stories) ? 'docs' : 'story',
+            tags: isV3DocsOnly(stories) ? [] : ['test', 'dev'],
             ...story,
+          }) satisfies V4Entry
+      ),
+    ])
+  );
+}
+
+/**
+ * Storybook 8.0 and below did not automatically tag stories with 'dev'.
+ * Therefore Storybook 8.1 and above would not show composed 8.0 stories by default.
+ * This function adds the 'dev' tag to all stories in the index to workaround this issue.
+ */
+function v4TitleMapToV5TitleMap(titleIdToStories: Record<string, V4Entry[]>) {
+  return Object.fromEntries(
+    Object.entries(titleIdToStories).map(([id, stories]) => [
+      id,
+      stories.map(
+        (story) =>
+          ({
+            ...story,
+            tags: story.tags ? ['test', 'dev', ...story.tags] : ['test', 'dev'],
           }) satisfies V4Entry
       ),
     ])
@@ -120,9 +147,11 @@ export const transformPlaywrightJson = (index: V3StoriesIndex | V4Index | Unsupp
       Object.values((index as V3StoriesIndex).stories)
     );
     titleIdToEntries = v3TitleMapToV4TitleMap(titleIdToStories);
-    // v4 and v5 are pretty much similar, so we process it in the same way
-  } else if (index.v === 4 || index.v === 5) {
+  } else if (index.v === 4) {
     // TODO: Once Storybook 8.0 is released, we should only support v4 and higher
+    titleIdToEntries = groupByTitleId<V4Entry>(Object.values((index as V4Index).entries));
+    titleIdToEntries = v4TitleMapToV5TitleMap(titleIdToEntries);
+  } else if (index.v === 5) {
     titleIdToEntries = groupByTitleId<V4Entry>(Object.values((index as V4Index).entries));
   } else {
     throw new Error(`Unsupported version ${index.v}`);

--- a/src/playwright/transformPlaywrightJson.ts
+++ b/src/playwright/transformPlaywrightJson.ts
@@ -120,7 +120,7 @@ export const transformPlaywrightJson = (index: V3StoriesIndex | V4Index | Unsupp
       Object.values((index as V3StoriesIndex).stories)
     );
     titleIdToEntries = v3TitleMapToV4TitleMap(titleIdToStories);
-  // v4 and v5 are pretty much similar, so we process it in the same way
+    // v4 and v5 are pretty much similar, so we process it in the same way
   } else if (index.v === 4 || index.v === 5) {
     // TODO: Once Storybook 8.0 is released, we should only support v4 and higher
     titleIdToEntries = groupByTitleId<V4Entry>(Object.values((index as V4Index).entries));

--- a/src/util/getTagOptions.ts
+++ b/src/util/getTagOptions.ts
@@ -15,7 +15,7 @@ export function getTagOptions() {
   const config = getTestRunnerConfig();
 
   let tagOptions = {
-    includeTags: config?.tags?.include || [],
+    includeTags: config?.tags?.include || ['test'],
     excludeTags: config?.tags?.exclude || [],
     skipTags: config?.tags?.skip || [],
   } as TagOptions;


### PR DESCRIPTION
Closes #484

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR fixes the issue with tag filtering inconsistency between non-index-json mode and index-json mode.
Additionally, it adds a default include filter for stories tagged as `test`. It has backwards compatibility with older indexes such as v3 and v4.

## Checklist for Contributors

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes in this repository
- [ ] Request documentation updates in the [test-runner docs website](https://storybook.js.org/docs/writing-tests/test-runner)

<!-- Regarding requesting documentation updates, please notify the maintainers of this repo in this PR. -->

## Checklist for Maintainers

- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `skip-release`: Skip any releases, e.g., documentation only changes, CI config etc.
  - `patch`: Upgrade patch version (e.g. 0.0.x)
  - `minor`: Upgrade patch version (e.g. 0.x.0)
  - `major`: Upgrade patch version (e.g. x.0.0)

   </details>

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.18.3--canary.485.a54e616.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/test-runner@0.18.3--canary.485.a54e616.0
  # or 
  yarn add @storybook/test-runner@0.18.3--canary.485.a54e616.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
