### PR TITLE
fix(deps): upgrade `@storybook/csf` to v0.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/types": "^7.22.5",
     "@jest/types": "^29.6.3",
     "@storybook/core-common": "next",
-    "@storybook/csf": "^0.1.2",
+    "@storybook/csf": "^0.1.11",
     "@storybook/csf-tools": "next",
     "@storybook/preview-api": "next",
     "@swc/core": "^1.5.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,7 +3727,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/csf@npm:^0.1.2, @storybook/csf@npm:^0.1.7":
+"@storybook/csf@npm:^0.1.11":
+  version: 0.1.11
+  resolution: "@storybook/csf@npm:0.1.11"
+  dependencies:
+    type-fest: ^2.19.0
+  checksum: ba2a265f62ad82a2853b069f77e974efe31bed263a640ca1dd8e6d7e194022018a67ad4a2587ae928f33ae45aaf6ffedd5925ba3fcf3fe5b7996667a918e22eb
+  languageName: node
+  linkType: hard
+
+"@storybook/csf@npm:^0.1.7":
   version: 0.1.7
   resolution: "@storybook/csf@npm:0.1.7"
   dependencies:
@@ -3971,7 +3980,7 @@ __metadata:
     "@storybook/addon-essentials": next
     "@storybook/addon-interactions": next
     "@storybook/core-common": next
-    "@storybook/csf": ^0.1.2
+    "@storybook/csf": ^0.1.11
     "@storybook/csf-tools": next
     "@storybook/preview-api": next
     "@storybook/react": next


### PR DESCRIPTION
This should ensure that the `combineTags` helper is available as older versions of the package did not have it.

Closes https://github.com/storybookjs/test-runner/issues/487

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

<!-- Briefly describe what your PR does -->

## Checklist for Contributors

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes in this repository
- [ ] Request documentation updates in the [test-runner docs website](https://storybook.js.org/docs/writing-tests/test-runner)

<!-- Regarding requesting documentation updates, please notify the maintainers of this repo in this PR. -->

## Checklist for Maintainers

- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `skip-release`: Skip any releases, e.g., documentation only changes, CI config etc.
  - `patch`: Upgrade patch version (e.g. 0.0.x)
  - `minor`: Upgrade patch version (e.g. 0.x.0)
  - `major`: Upgrade patch version (e.g. x.0.0)

   </details>
