### PR TITLE
Feature: Run postVisit on failures

### DIFF
--- a/src/csf/__snapshots__/transformCsf.test.ts.snap
+++ b/src/csf/__snapshots__/transformCsf.test.ts.snap
@@ -29,12 +29,25 @@ if (!require.main) {
           if (globalThis.__sbPreVisit) {
             await globalThis.__sbPreVisit(page, context);
           }
-          const result = await page.evaluate(({
-            id,
-            hasPlayFn
-          }) => __test(id, hasPlayFn), {
-            id: "button--primary"
-          });
+          let result;
+          try {
+            result = await page.evaluate(({
+              id,
+              hasPlayFn
+            }) => __test(id, hasPlayFn), {
+              id: "button--primary"
+            });
+          } catch (err) {
+            if (err.toString().includes('Execution context was destroyed')) {
+              throw err;
+            } else {
+              await globalThis.__sbPostVisit(page, {
+                ...context,
+                hasFailure: true
+              });
+              throw err;
+            }
+          }
           if (globalThis.__sbPostVisit) {
             await globalThis.__sbPostVisit(page, context);
           }
@@ -96,12 +109,25 @@ if (!require.main) {
           if (globalThis.__sbPreVisit) {
             await globalThis.__sbPreVisit(page, context);
           }
-          const result = await page.evaluate(({
-            id,
-            hasPlayFn
-          }) => __test(id, hasPlayFn), {
-            id: "button--primary"
-          });
+          let result;
+          try {
+            result = await page.evaluate(({
+              id,
+              hasPlayFn
+            }) => __test(id, hasPlayFn), {
+              id: "button--primary"
+            });
+          } catch (err) {
+            if (err.toString().includes('Execution context was destroyed')) {
+              throw err;
+            } else {
+              await globalThis.__sbPostVisit(page, {
+                ...context,
+                hasFailure: true
+              });
+              throw err;
+            }
+          }
           if (globalThis.__sbPostVisit) {
             await globalThis.__sbPostVisit(page, context);
           }
@@ -149,12 +175,25 @@ if (!require.main) {
           if (globalThis.__sbPreVisit) {
             await globalThis.__sbPreVisit(page, context);
           }
-          const result = await page.evaluate(({
-            id,
-            hasPlayFn
-          }) => __test(id, hasPlayFn), {
-            id: "button--primary"
-          });
+          let result;
+          try {
+            result = await page.evaluate(({
+              id,
+              hasPlayFn
+            }) => __test(id, hasPlayFn), {
+              id: "button--primary"
+            });
+          } catch (err) {
+            if (err.toString().includes('Execution context was destroyed')) {
+              throw err;
+            } else {
+              await globalThis.__sbPostVisit(page, {
+                ...context,
+                hasFailure: true
+              });
+              throw err;
+            }
+          }
           if (globalThis.__sbPostVisit) {
             await globalThis.__sbPostVisit(page, context);
           }

--- a/src/playwright/hooks.ts
+++ b/src/playwright/hooks.ts
@@ -5,6 +5,7 @@ export type TestContext = {
   id: string;
   title: string;
   name: string;
+  hasFailure?: boolean;
 };
 
 export type PrepareContext = {

--- a/src/playwright/transformPlaywright.test.ts
+++ b/src/playwright/transformPlaywright.test.ts
@@ -70,12 +70,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--a"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--a"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -115,12 +128,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--b"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--b"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -178,12 +204,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--b"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--b"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -241,12 +280,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--a"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--a"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -286,12 +338,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--b"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--b"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -362,12 +427,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--b"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--b"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -407,12 +485,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--c"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--c"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -452,12 +543,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--d"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--d"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -497,12 +601,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--e"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--e"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -566,12 +683,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--a"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--a"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -611,12 +741,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--c"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--c"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -676,12 +819,25 @@ describe('Playwright', () => {
                   if (globalThis.__sbPreVisit) {
                     await globalThis.__sbPreVisit(page, context);
                   }
-                  const result = await page.evaluate(({
-                    id,
-                    hasPlayFn
-                  }) => __test(id, hasPlayFn), {
-                    id: "example-foo-bar--a"
-                  });
+                  let result;
+                  try {
+                    result = await page.evaluate(({
+                      id,
+                      hasPlayFn
+                    }) => __test(id, hasPlayFn), {
+                      id: "example-foo-bar--a"
+                    });
+                  } catch (err) {
+                    if (err.toString().includes('Execution context was destroyed')) {
+                      throw err;
+                    } else {
+                      await globalThis.__sbPostVisit(page, {
+                        ...context,
+                        hasFailure: true
+                      });
+                      throw err;
+                    }
+                  }
                   if (globalThis.__sbPostVisit) {
                     await globalThis.__sbPostVisit(page, context);
                   }
@@ -753,12 +909,25 @@ describe('Playwright', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-foo-bar--a"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-foo-bar--a"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -814,12 +983,25 @@ describe('Playwright', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-foo-bar--a"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-foo-bar--a"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -875,12 +1057,25 @@ describe('Playwright', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-header--a"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-header--a"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }

--- a/src/playwright/transformPlaywrightJson.test.ts
+++ b/src/playwright/transformPlaywrightJson.test.ts
@@ -55,12 +55,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-header--logged-in"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-header--logged-in"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -100,12 +113,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-header--logged-out"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-header--logged-out"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -147,12 +173,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-page--logged-in"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-page--logged-in"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -241,12 +280,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-b"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-b"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -288,12 +340,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-c"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-c"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -358,12 +423,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-page--logged-in"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-page--logged-in"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -449,12 +527,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-header--logged-in"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-header--logged-in"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -494,12 +585,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-header--logged-out"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-header--logged-out"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -541,12 +645,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-page--logged-in"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-page--logged-in"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -620,12 +737,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-page--logged-in"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-page--logged-in"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }
@@ -690,12 +820,25 @@ describe('Playwright Json', () => {
                 if (globalThis.__sbPreVisit) {
                   await globalThis.__sbPreVisit(page, context);
                 }
-                const result = await page.evaluate(({
-                  id,
-                  hasPlayFn
-                }) => __test(id, hasPlayFn), {
-                  id: "example-page--logged-in"
-                });
+                let result;
+                try {
+                  result = await page.evaluate(({
+                    id,
+                    hasPlayFn
+                  }) => __test(id, hasPlayFn), {
+                    id: "example-page--logged-in"
+                  });
+                } catch (err) {
+                  if (err.toString().includes('Execution context was destroyed')) {
+                    throw err;
+                  } else {
+                    await globalThis.__sbPostVisit(page, {
+                      ...context,
+                      hasFailure: true
+                    });
+                    throw err;
+                  }
+                }
                 if (globalThis.__sbPostVisit) {
                   await globalThis.__sbPostVisit(page, context);
                 }


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Experiment for allowing postVisit to be run on failures so you can do things like:

```ts
const config: TestRunnerConfig = {
  async postVisit(_page, context) {
    if(context.hasFailure) {
      console.log('problems!', context)
    }
  },
}
```

## Checklist for Contributors

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes in this repository
- [ ] Request documentation updates in the [test-runner docs website](https://storybook.js.org/docs/writing-tests/test-runner)

<!-- Regarding requesting documentation updates, please notify the maintainers of this repo in this PR. -->

## Checklist for Maintainers

- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `skip-release`: Skip any releases, e.g., documentation only changes, CI config etc.
  - `patch`: Upgrade patch version (e.g. 0.0.x)
  - `minor`: Upgrade patch version (e.g. 0.x.0)
  - `major`: Upgrade patch version (e.g. x.0.0)

   </details>
