### PR TITLE
fix: gracefully kill process on SIGINT and exit

### DIFF
--- a/src/test-storybook.ts
+++ b/src/test-storybook.ts
@@ -96,6 +96,7 @@ const onProcessEnd = () => {
   if (process.env.STORYBOOK_COLLECT_COVERAGE === 'true') {
     reportCoverage();
   }
+  process.exit(0);
 };
 
 process.on('SIGINT', onProcessEnd);


### PR DESCRIPTION
WIP

Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

SIGINT is a signal that is generally used to indicate a program is being interrupted by the user (like when entering "ctrl + c") and allows a program to be gracefully terminated.

The event handler for `SIGINT` (as well as exit) does not actually kill the process so when the user tries to interrupt the program, the process is left hanging which is not what is expected for CLI programs in general. As it is right now, the entire test suite needs to complete running before the program exits. For large test suites, this is a notable waste of time.

This commit is simply killing the process upon a SIGINT or exit event.

## Checklist for Contributors

#### Manual testing

1. 

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes in this repository
- [ ] Request documentation updates in the [test-runner docs website](https://storybook.js.org/docs/writing-tests/test-runner)

<!-- Regarding requesting documentation updates, please notify the maintainers of this repo in this PR. -->

## Checklist for Maintainers

- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `skip-release`: Skip any releases, e.g., documentation only changes, CI config etc.
  - `patch`: Upgrade patch version (e.g. 0.0.x)
  - `minor`: Upgrade patch version (e.g. 0.x.0)
  - `major`: Upgrade patch version (e.g. x.0.0)

   </details>
