### PR TITLE
Fix --index-json flag not being honored for locally deployed storybooks

### DIFF
--- a/src/test-storybook.ts
+++ b/src/test-storybook.ts
@@ -362,7 +362,8 @@ const main = async () => {
   const { hostname } = new URL(targetURL);
 
   const isLocalStorybookIp = await canBindToHost(hostname);
-  const shouldRunIndexJson = runnerOptions.indexJson !== false && !isLocalStorybookIp;
+  const shouldRunIndexJson =
+    runnerOptions.indexJson === true || (runnerOptions.indexJson !== false && !isLocalStorybookIp);
   if (shouldRunIndexJson) {
     log(
       'Detected a remote Storybook URL, running in index json mode. To disable this, run the command again with --no-index-json\n'


### PR DESCRIPTION
Closes #538

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

Fix the bug where index-json flag is not honored for locally deployed storybooks

## Checklist for Contributors

#### Manual testing

I tested this in an internal repo for my org.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes in this repository
- [ ] Request documentation updates in the [test-runner docs website](https://storybook.js.org/docs/writing-tests/test-runner)

<!-- Regarding requesting documentation updates, please notify the maintainers of this repo in this PR. -->

## Checklist for Maintainers

- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `skip-release`: Skip any releases, e.g., documentation only changes, CI config etc.
  - `patch`: Upgrade patch version (e.g. 0.0.x)
  - `minor`: Upgrade patch version (e.g. 0.x.0)
  - `major`: Upgrade patch version (e.g. x.0.0)

   </details>
