### PR TITLE
fix: Use StoryFinished event if available

### DIFF
--- a/src/setup-page.ts
+++ b/src/setup-page.ts
@@ -36,7 +36,7 @@ export const setupPage = async (page: Page, browserContext: BrowserContext) => {
   const failOnConsole = process.env.TEST_CHECK_CONSOLE;
 
   const viewMode = process.env.VIEW_MODE ?? 'story';
-  const renderedEvent = viewMode === 'docs' ? 'docsRendered' : 'storyRendered';
+  const renderedEvent = viewMode === 'docs' ? 'globalThis.__STORYBOOK_MODULE_CORE_EVENTS__.DOCS_RENDERED' : 'globalThis.__STORYBOOK_MODULE_CORE_EVENTS__.STORY_FINISHED ?? globalThis.__STORYBOOK_MODULE_CORE_EVENTS__.STORY_RENDERED';
   const { packageJson } = (await readPackageUp()) as NormalizedReadResult;
   const { version: testRunnerVersion } = packageJson;
 
@@ -82,7 +82,7 @@ export const setupPage = async (page: Page, browserContext: BrowserContext) => {
   const content = (await readFile(scriptLocation, 'utf-8'))
     .replaceAll('{{storybookUrl}}', finalStorybookUrl)
     .replaceAll('{{failOnConsole}}', failOnConsole ?? 'false')
-    .replaceAll('{{renderedEvent}}', renderedEvent)
+    .replaceAll('"{{renderedEvent}}"', renderedEvent)
     .replaceAll('{{testRunnerVersion}}', testRunnerVersion)
     .replaceAll('{{logLevel}}', testRunnerConfig.logLevel ?? 'info')
     .replaceAll('{{debugPrintLimit}}', debugPrintLimit.toString());


### PR DESCRIPTION
Closes https://github.com/storybookjs/storybook/issues/30472
Closes https://github.com/storybookjs/storybook/issues/30385
Relates https://github.com/storybookjs/test-runner/issues/68#issuecomment-2669476600

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

The test-runner used the `storyRendered` event to determine whether a story has finished rendering, including executing `play` functions. In Storybook 8.4, we have introduced a new Storybook lifecycle step called `storyFinished`, which waits for `storyRendered` **and** `afterEach` calls on a story. The `@storybook/addon-a11y` addon for example registers an `afterEach` hook to run axe-based accessibility tests. 

When the `test-runner` was for example set up with `axe-playwright` it happened, that `axe` was running twice. Once from `@storybook/addon-a11y` during the afterEach lifecycle and from `axe-playwright` itself. `axe` though is not allowed to be run in parallel. This issue is fixed by waiting for the `storyFinished` instead of the `storyRendered` event. So now `@storybook/addon-a11y` first finishes its accessibility run before playwright starts its own a11y run.

Second, due to the a11y checks in `@storybook/addon-a11y` a story remained in the `afterEach` lifecycle for a longer time, although the test-runner already triggered a test run for the next story. This led to issues like the one described [here](https://github.com/storybookjs/test-runner/issues/68#issuecomment-2669476600).

## Checklist for Contributors

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes in this repository
- [ ] Request documentation updates in the [test-runner docs website](https://storybook.js.org/docs/writing-tests/test-runner)

<!-- Regarding requesting documentation updates, please notify the maintainers of this repo in this PR. -->

## Checklist for Maintainers

- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `skip-release`: Skip any releases, e.g., documentation only changes, CI config etc.
  - `patch`: Upgrade patch version (e.g. 0.0.x)
  - `minor`: Upgrade patch version (e.g. 0.x.0)
  - `major`: Upgrade patch version (e.g. x.0.0)

   </details>
