### PR TITLE
Add out of the box support for a11y tests

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -14,7 +14,7 @@ const preview: Preview = {
   decorators: [withSkippableTests],
   parameters: {
     a11y: {
-      test: 'todo',
+      test: 'error',
       config: {
         rules: [
           {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -14,6 +14,7 @@ const preview: Preview = {
   decorators: [withSkippableTests],
   parameters: {
     a11y: {
+      test: 'todo',
       config: {
         rules: [
           {

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -1,5 +1,4 @@
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
-import { injectAxe, checkA11y, configureAxe } from 'axe-playwright';
 
 import { getStoryContext, waitForPageReady } from '../dist';
 import type { TestRunnerConfig } from '../dist';
@@ -20,9 +19,6 @@ const config: TestRunnerConfig = {
   },
   setup() {
     expect.extend({ toMatchImageSnapshot });
-  },
-  async preVisit(page) {
-    await injectAxe(page);
   },
   async postVisit(page, context) {
     // Get entire context of a story, including parameters, args, argTypes, etc.
@@ -51,18 +47,6 @@ const config: TestRunnerConfig = {
     const innerHTML = await elementHandler?.innerHTML();
     // HTML snapshot tests
     expect(innerHTML).toMatchSnapshot();
-
-    await configureAxe(page, {
-      rules: parameters?.a11y?.config?.rules,
-    });
-
-    const element = parameters?.a11y?.element ?? 'body';
-    await checkA11y(page, element, {
-      detailedReport: true,
-      detailedReportOptions: {
-        html: true,
-      },
-    });
   },
 };
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Storybook test runner turns all of your stories into executable tests.
 - [Recipes](#recipes)
   - [Preconfiguring viewport size](#preconfiguring-viewport-size)
   - [Accessibility testing](#accessibility-testing)
+    - [With Storybook 9](#with-storybook-9)
+    - [With Storybook 8](#with-storybook-8)
   - [DOM snapshot (HTML)](#dom-snapshot-html)
   - [Image snapshot](#image-snapshot)
 - [Troubleshooting](#troubleshooting)
@@ -167,7 +169,7 @@ Usage: test-storybook [options]
 | `--json`                          | Prints the test results in JSON. This mode will send all other test output and user messages to stderr. <br/>`test-storybook --json`                                          |
 | `--outputFile`                    | Write test results to a file when the --json option is also specified. <br/>`test-storybook --json --outputFile results.json`                                                 |
 | `--junit`                         | Indicates that test information should be reported in a junit file. <br/>`test-storybook --**junit**`                                                                         |
-| `--listTests`                     | Lists all test files that will be run, and exits<br/>`test-storybook --listTests`                                                                         |
+| `--listTests`                     | Lists all test files that will be run, and exits<br/>`test-storybook --listTests`                                                                                             |
 | `--ci`                            | Instead of the regular behavior of storing a new snapshot automatically, it will fail the test and require Jest to be run with `--updateSnapshot`. <br/>`test-storybook --ci` |
 | `--shard [shardIndex/shardCount]` | Splits your test suite across different machines to run in CI. <br/>`test-storybook --shard=1/3`                                                                              |
 | `--failOnConsole`                 | Makes tests fail on browser console errors<br/>`test-storybook --failOnConsole`                                                                                               |
@@ -884,6 +886,32 @@ export default config;
 ```
 
 ### Accessibility testing
+
+#### With Storybook 9
+
+In Storybook 9, the accessibility addon has been enhanced with automated reporting capabilities and the Test-runner has out of the box support for it. If you have `@storybook/addon-a11y` installed, as long as you enable them via parameters, you will get a11y checks for every story:
+
+```ts
+// .storybook/preview.ts
+
+const preview = {
+  parameters: {
+    a11y: {
+      // 'error' will cause a11y violations to fail tests
+      test: 'error', // or 'todo' or 'off'
+    },
+  },
+};
+
+export default preview;
+```
+
+If you had a11y tests set up previously for Storybook 8 (with the recipe below), you can uninstall `axe-playwright` and remove all the code from the test-runner hooks, as they are not necessary anymore.
+
+#### With Storybook 8
+
+> [!TIP]
+> If you upgrade to Storybook 9, there is out of the box support for a11y tests and you don't have to follow a recipe like this.
 
 You can install `axe-playwright` and use it in tandem with the test-runner to test the accessibility of your components.
 If you use [`@storybook/addon-a11y`](https://storybook.js.org/addons/@storybook/addon-a11y), you can reuse its parameters and make sure that the tests match in configuration, both in the accessibility addon panel and the test-runner.

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@types/node-fetch": "^2.6.11",
     "@vitejs/plugin-react": "^4.0.3",
     "auto": "^11.1.6",
-    "axe-playwright": "^2.1.0",
     "babel-jest": "^29.0.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-istanbul": "^6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,7 +2951,6 @@ __metadata:
     "@types/node-fetch": "npm:^2.6.11"
     "@vitejs/plugin-react": "npm:^4.0.3"
     auto: "npm:^11.1.6"
-    axe-playwright: "npm:^2.1.0"
     babel-jest: "npm:^29.0.0"
     babel-loader: "npm:^8.1.0"
     babel-plugin-istanbul: "npm:^6.1.1"
@@ -3337,13 +3336,6 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10/1a3c3e06236e4c4aab89499c428d585527ce50c24fe8259e8b3926d3df4cfbbbcf306cfc73ddfb66cbafc973116efd15967020b0f738f63e09e64c7d260519e7
-  languageName: node
-  linkType: hard
-
-"@types/junit-report-builder@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "@types/junit-report-builder@npm:3.0.2"
-  checksum: 10/7fead0b771f95cd8e607223ace2f43cc881b3e7944db405f903590b56379d14132032b7d89c9afa7dff266b95f516a476a39ad40f9200bfb61fc8ed7f6b1bff6
   languageName: node
   linkType: hard
 
@@ -3820,36 +3812,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:^4.10.1, axe-core@npm:^4.2.0":
+"axe-core@npm:^4.2.0":
   version: 4.10.3
   resolution: "axe-core@npm:4.10.3"
   checksum: 10/9ff51ad0fd0fdec5c0247ea74e8ace5990b54c7f01f8fa3e5cd8ba98b0db24d8ebd7bab4a9bd4d75c28c4edcd1eac455b44c8c6c258c6a98f3d2f88bc60af4cc
-  languageName: node
-  linkType: hard
-
-"axe-html-reporter@npm:2.2.11":
-  version: 2.2.11
-  resolution: "axe-html-reporter@npm:2.2.11"
-  dependencies:
-    mustache: "npm:^4.0.1"
-  peerDependencies:
-    axe-core: ">=3"
-  checksum: 10/489a904c62fe5c74db9490773a624e8573906b54a9c8264b831ee50b648f623ba292a011598d257bd6b8dc35eede21998fc25c799bd99eb9ca8ecf2d05ef92a1
-  languageName: node
-  linkType: hard
-
-"axe-playwright@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "axe-playwright@npm:2.1.0"
-  dependencies:
-    "@types/junit-report-builder": "npm:^3.0.2"
-    axe-core: "npm:^4.10.1"
-    axe-html-reporter: "npm:2.2.11"
-    junit-report-builder: "npm:^5.1.1"
-    picocolors: "npm:^1.1.1"
-  peerDependencies:
-    playwright: ">1.0.0"
-  checksum: 10/d478c206bdd950257fafc872a6da3d9e73ca6a235ecea504bfde9744ca9265cc7abea050301c7cb611a3e79d61e14d50a047595c6e6cc13353e6c1c835afe922
   languageName: node
   linkType: hard
 
@@ -6973,17 +6939,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"junit-report-builder@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "junit-report-builder@npm:5.1.1"
-  dependencies:
-    lodash: "npm:^4.17.21"
-    make-dir: "npm:^3.1.0"
-    xmlbuilder: "npm:^15.1.1"
-  checksum: 10/273678301654c22265a8ccd5a605f498747e2530e801b332f1033fa3e35b3fc3538e10b335674cca41bbc1f4c9476350254820e1f5f0cf4101ac8dd4c1402bf8
-  languageName: node
-  linkType: hard
-
 "kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
@@ -7551,15 +7506,6 @@ __metadata:
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10/aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
-  languageName: node
-  linkType: hard
-
-"mustache@npm:^4.0.1":
-  version: 4.2.0
-  resolution: "mustache@npm:4.2.0"
-  bin:
-    mustache: bin/mustache
-  checksum: 10/6e668bd5803255ab0779c3983b9412b5c4f4f90e822230e0e8f414f5449ed7a137eed29430e835aa689886f663385cfe05f808eb34b16e1f3a95525889b05cd3
   languageName: node
   linkType: hard
 
@@ -10362,13 +10308,6 @@ __metadata:
   version: 1.0.1
   resolution: "xml@npm:1.0.1"
   checksum: 10/6c4c31a1308e45732e5ac6b50edbca0e8f7abe5cb5de10215d8e3c688819fe7c7706e056f6fb59b1a23fdf1000c2d7a8bba0a89e94aa1796cd2376d9a5ba401e
-  languageName: node
-  linkType: hard
-
-"xmlbuilder@npm:^15.1.1":
-  version: 15.1.1
-  resolution: "xmlbuilder@npm:15.1.1"
-  checksum: 10/e6f4bab2504afdd5f80491bda948894d2146756532521dbe7db33ae0931cd3000e3b4da19b3f5b3f51bedbd9ee06582144d28136d68bd1df96579ecf4d4404a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

**Before:**
- Users had to install `axe-playwright` and write code from a recipe with test-runner hooks
- It was easy to miss passing the story context to the a11y report and therefore there would be a mismatch between the addon a11y settings and the a11y test in the test-runner
- Logs weren't attached to the test result
- Logs took a lot of space and were hard to parse
![image](https://github.com/user-attachments/assets/28ecab3a-3b78-4da5-b241-73dd3ab629a1)

**After:**
- No need for extra dependencies, works out of the box
- Respects the `a11y.test` parameter as [per the docs](https://storybook.js.org/docs/writing-tests/accessibility-testing#configure-accessibility-tests-with-the-test-addon)
- Error logs are attached to the test result
- Logs are formatted and easy to parse
- There is a link to debug directly in the a11y panel
![image](https://github.com/user-attachments/assets/528d7bf2-f311-43a3-b5a4-445df8ffbdb8)

Additionally, there is the `a11y.test: 'todo'` mode, where the tests pass but there are shorter logs in the report.
We should discuss how this should work. Unfortunately the logs aren't attached to the report in this mode.
![image](https://github.com/user-attachments/assets/8a0f1422-d778-4101-b67f-0eb830f57376)


## Checklist for Contributors

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes in this repository
- [ ] Request documentation updates in the [test-runner docs website](https://storybook.js.org/docs/writing-tests/test-runner)

<!-- Regarding requesting documentation updates, please notify the maintainers of this repo in this PR. -->

## Checklist for Maintainers

- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `skip-release`: Skip any releases, e.g., documentation only changes, CI config etc.
  - `patch`: Upgrade patch version (e.g. 0.0.x)
  - `minor`: Upgrade patch version (e.g. 0.x.0)
  - `major`: Upgrade patch version (e.g. x.0.0)

   </details>
