### PR TITLE
Updated the recipe to use `storybook/viewport`

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,12 +850,12 @@ Below you will find recipes that use both the hooks and the utility functions to
 
 ### Preconfiguring viewport size
 
-You can use [Playwright's Page viewport utility](https://playwright.dev/docs/api/class-page#page-set-viewport-size) to programatically change the viewport size of your test. If you use [@storybook/addon-viewports](https://storybook.js.org/addons/@storybook/addon-viewport), you can reuse its parameters and make sure that the tests match in configuration.
+You can use [Playwright's Page viewport utility](https://playwright.dev/docs/api/class-page#page-set-viewport-size) to programatically change the viewport size of your test. If you use [storybook/viewports](https://storybook.js.org/addons/@storybook/addon-viewport), you can reuse its parameters and make sure that the tests match in configuration.
 
 ```ts
 // .storybook/test-runner.ts
 import { TestRunnerConfig, getStoryContext } from '@storybook/test-runner';
-import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { MINIMAL_VIEWPORTS } from 'storybook/viewport';
 
 const DEFAULT_VIEWPORT_SIZE = { width: 1280, height: 720 };
 


### PR DESCRIPTION
## What I did

<!-- Briefly describe what your PR does -->

Since `@storybook/addon-viewport` was renamed to `storybook/viewport` in Storybook v9, I updated the `Preconfiguring viewport size` section in the README to use `storybook/viewport`.

> Migration guide for Storybook 9
> Package structure changes
> 
> |Removal | Replacement|
> |---|---|
> |`@storybook/addon-viewport`|`storybook/viewport`|
>
> https://storybook.js.org/docs/releases/migration-guide#package-structure-changes

## Checklist for Contributors

#### Manual testing

No manual testing is necessary as this is a documentation-only change that updates package references in the README to reflect the Storybook v9 package structure changes.

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [x] Add or update documentation reflecting your changes in this repository
- [ ] Request documentation updates in the [test-runner docs website](https://storybook.js.org/docs/writing-tests/test-runner)

<!-- Regarding requesting documentation updates, please notify the maintainers of this repo in this PR. -->

## Checklist for Maintainers

- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `skip-release`: Skip any releases, e.g., documentation only changes, CI config etc.
  - `patch`: Upgrade patch version (e.g. 0.0.x)
  - `minor`: Upgrade patch version (e.g. 0.x.0)
  - `major`: Upgrade patch version (e.g. x.0.0)

   </details>