### PR TITLE
chore: bump playwright to 1.56.1 to fix npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "jest-serializer-html": "^7.1.0",
     "jest-watch-typeahead": "^3.0.1",
     "nyc": "^15.1.0",
-    "playwright": "^1.14.0",
-    "playwright-core": ">=1.2.0",
+    "playwright": ">=1.56.1",
+    "playwright-core": ">=1.56.1",
     "rimraf": "^3.0.2",
     "uuid": "^8.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2975,7 +2975,7 @@ __metadata:
     pkg-up: "npm:^5.0.0"
     playwright: "npm:>=1.56.1"
     playwright-chromium: "npm:>=1.56.1"
-    playwright-core: "npm:>=1.2.0"
+    playwright-core: "npm:>=1.56.1"
     prettier: "npm:^2.8.1"
     react: "npm:^17.0.1"
     react-dom: "npm:^17.0.1"
@@ -8485,21 +8485,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.56.1":
+"playwright-core@npm:1.56.1, playwright-core@npm:>=1.56.1":
   version: 1.56.1
   resolution: "playwright-core@npm:1.56.1"
   bin:
     playwright-core: cli.js
   checksum: 10/df785eb3b3a8392b10dcde5f768e09b7fe459a7b06ed81180da69e048f2154b761f86d79572c2b62037a1f18a44e4ace72f5b6547f4f473b4ab13ab1d94007d2
-  languageName: node
-  linkType: hard
-
-"playwright-core@npm:>=1.2.0":
-  version: 1.54.1
-  resolution: "playwright-core@npm:1.54.1"
-  bin:
-    playwright-core: cli.js
-  checksum: 10/c0acfb7ecb48e9fb6c22f71298b966244bd4f8659093a798cc7f9a509deee22109560e44f2d507124e7718779640e0b4cb05a05c068b034405418d8740ec31ff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes dependency on a faulty version of Playwright:
Playwright downloads and installs browsers without verifying the authenticity of the SSL certificate: https://github.com/advisories/GHSA-7mvr-c777-76hp
Bumps Playwright to 1.56.1 - version that contains the fix.