### PR TITLE
Use proxy to avoid modifying console method arguments in-place when serializing them

### DIFF
--- a/src/setup-page-script.ts
+++ b/src/setup-page-script.ts
@@ -63,6 +63,69 @@ function defaultOptions(): { depthLimit: number; edgesLimit: number } {
   };
 }
 
+const copyOnWriteProxySet = new WeakSet();
+function copyOnWriteProxy<T>(target: T): T {
+  if (!target || typeof target !== "object") {
+    return target;
+  }
+
+  const deletedProperties = new Set();
+  const modifiedProperties = new Set();
+  const modififications = {};
+  const proxy = new Proxy(target, {
+    get(target, prop, receiver) {
+      if (deletedProperties.has(prop)) {
+        return undefined;
+      }
+
+      const source = modifiedProperties.has(prop) ? modififications : target;
+      const value = Reflect.get(source, prop, receiver);
+
+      if (value && typeof value === "object" && !copyOnWriteProxySet.has(value)) {
+        const proxiedValue = copyOnWriteProxy(value);
+        Reflect.set(proxy, prop, proxiedValue, receiver);
+        return proxiedValue;
+      }
+
+      return value;
+    },
+    set(_, prop, value, receiver) {
+      modifiedProperties.add(prop);
+      deletedProperties.delete(prop);
+      return Reflect.set(modififications, prop, value, receiver);
+    },
+    deleteProperty(_, prop) {
+      deletedProperties.add(prop);
+      modifiedProperties.delete(prop);
+      return Reflect.deleteProperty(modififications, prop) || Reflect.has(target, prop);
+    },
+    has(target, prop) {
+      if (deletedProperties.has(prop)) {
+        return false;
+      }
+      return Reflect.has(target, prop) || Reflect.has(modififications, prop);
+    },
+    defineProperty(_, prop, descriptor) {
+      modifiedProperties.add(prop);
+      deletedProperties.delete(prop);
+      return Reflect.defineProperty(target, prop, descriptor);
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      if (deletedProperties.has(prop)) {
+        return undefined;
+      }
+      return Reflect.getOwnPropertyDescriptor(modififications, prop) || Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+    ownKeys(target) {
+      return [...new Set([...Reflect.ownKeys(target), ...Reflect.ownKeys(modififications)]).difference(deletedProperties)];
+    },
+  });
+
+  copyOnWriteProxySet.add(proxy);
+
+  return proxy;
+}
+
 // Stringify function
 function stringify(
   obj: any,
@@ -74,7 +137,7 @@ function stringify(
     options = defaultOptions();
   }
 
-  decirc(obj, '', 0, [], undefined, 0, options);
+  decirc(copyOnWriteProxy(obj), '', 0, [], undefined, 0, options);
   var res: string;
   try {
     if (replacerStack.length === 0) {


### PR DESCRIPTION
Closes #592

<!-- If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

<!--

Thank you for contributing to Storybook! Please submit all PRs to the `next` branch unless they are specific to the current release. Storybook maintainers cherry-pick bug and documentation fixes into the `main` branch as part of the release process, so you shouldn't need to worry about this. For additional guidance: https://storybook.js.org/docs/contribute

-->

## What I did

This PR is an attempted fix for #592 that relies on `Proxy` so that we can keep the existing serialization code as is but prevent all changes to arguments of `console.log`/`console.error`/etc — instead, if any modifications are attempted on the proxied object, they are stored separately.

## Checklist for Contributors

#### Manual testing

_This section is mandatory for all contributions. If you believe no manual test is necessary, please state so explicitly. Thanks!_

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes in this repository
- [ ] Request documentation updates in the [test-runner docs website](https://storybook.js.org/docs/writing-tests/test-runner)

<!-- Regarding requesting documentation updates, please notify the maintainers of this repo in this PR. -->

## Checklist for Maintainers

- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `skip-release`: Skip any releases, e.g., documentation only changes, CI config etc.
  - `patch`: Upgrade patch version (e.g. 0.0.x)
  - `minor`: Upgrade patch version (e.g. 0.x.0)
  - `major`: Upgrade patch version (e.g. x.0.0)

   </details>
