### PR TITLE
fix: dedupe generated browser tests to avoid doubled in-flight counters

### DIFF
--- a/src/jest-playwright-preset/PlaywrightRunner.test.ts
+++ b/src/jest-playwright-preset/PlaywrightRunner.test.ts
@@ -1,0 +1,38 @@
+import type { Test } from 'jest-runner';
+import { describe, it, expect } from 'vitest';
+import { dedupeBrowserTests } from './PlaywrightRunner';
+
+const makeTest = (overrides: Partial<any>): Test =>
+  ({
+    path: '/tmp/sample.test.js',
+    context: {
+      config: {
+        browserName: 'chromium',
+        deviceName: null,
+        displayName: { name: 'chromium' },
+      },
+    },
+    ...overrides,
+  } as unknown as Test);
+
+describe('dedupeBrowserTests', () => {
+  it('removes duplicated browser test entries with same path/browser/device/displayName', () => {
+    const base = makeTest({});
+    const duplicate = makeTest({});
+
+    const result = dedupeBrowserTests([base, duplicate]);
+    expect(result).toHaveLength(1);
+  });
+
+  it('keeps entries for different browsers', () => {
+    const chromium = makeTest({
+      context: { config: { browserName: 'chromium', deviceName: null, displayName: { name: 'chromium' } } },
+    });
+    const firefox = makeTest({
+      context: { config: { browserName: 'firefox', deviceName: null, displayName: { name: 'firefox' } } },
+    });
+
+    const result = dedupeBrowserTests([chromium, firefox]);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/src/jest-playwright-preset/PlaywrightRunner.ts
+++ b/src/jest-playwright-preset/PlaywrightRunner.ts
@@ -34,6 +34,33 @@ import {
 import { setupCoverage, mergeCoverage } from './coverage';
 import { GenericBrowser } from './types';
 
+const getTestDedupeKey = (test: Test) => {
+  const contextConfig = (test as any).context?.config || {};
+  const testPath = (test as any).path || '';
+  const browserName = contextConfig.browserName || '';
+  const deviceName = contextConfig.deviceName || '';
+  const displayName =
+    typeof contextConfig.displayName === 'string'
+      ? contextConfig.displayName
+      : contextConfig.displayName?.name || '';
+
+  return [testPath, browserName, deviceName, displayName].join('::');
+};
+
+export const dedupeBrowserTests = (tests: Test[]) => {
+  const seen = new Set<string>();
+  const deduped: Test[] = [];
+
+  for (const test of tests) {
+    const key = getTestDedupeKey(test);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(test);
+  }
+
+  return deduped;
+};
+
 const getBrowserTest = ({
   test,
   config,
@@ -166,7 +193,7 @@ class PlaywrightRunner extends JestRunner {
       }
     }
 
-    return pwTests;
+    return dedupeBrowserTests(pwTests);
   }
 
   async runTests(


### PR DESCRIPTION
Fixes #276

## Summary

When browser tests are expanded in `PlaywrightRunner#getTests`, duplicate generated entries can inflate in-flight test counters in Jest output (e.g. showing ~2x tests while running, then settling at the expected total at the end).

This patch dedupes generated browser tests before execution using a stable key:

- test path
- browser name
- device name
- display name

## Why this helps

The in-flight counter is based on the expanded test list. If that list contains duplicates, users see misleading progress totals.

By deduping before `super.runTests(...)`, progress reporting remains stable and matches final totals.

## Changes

- `src/jest-playwright-preset/PlaywrightRunner.ts`
  - add `dedupeBrowserTests` helper
  - apply it to the generated `pwTests` list

- `src/jest-playwright-preset/PlaywrightRunner.test.ts`
  - verifies duplicates are removed
  - verifies distinct browser entries are preserved

## Validation

```bash
corepack yarn test src/jest-playwright-preset/PlaywrightRunner.test.ts
```

