### PR TITLE
fix: substitute {{viewMode}} placeholder in setup-page-script

### DIFF
--- a/src/setup-page.ts
+++ b/src/setup-page.ts
@@ -91,7 +91,8 @@ export const setupPage = async (page: Page, browserContext: BrowserContext) => {
     .replaceAll('"{{renderedEvent}}"', renderedEvent)
     .replaceAll('{{testRunnerVersion}}', testRunnerVersion)
     .replaceAll('{{logLevel}}', testRunnerConfig.logLevel ?? 'info')
-    .replaceAll('{{debugPrintLimit}}', debugPrintLimit.toString());
+    .replaceAll('{{debugPrintLimit}}', debugPrintLimit.toString())
+    .replaceAll('{{viewMode}}', viewMode);
 
   await page.addScriptTag({ content });
 };


### PR DESCRIPTION
(LLM-powered WIP, I will clean up the PR description shortly)

## Problem

`setup-page-script.ts` declares:

```ts
const TEST_RUNNER_VIEW_MODE: string = '{{viewMode}}';
```

and emits it on every story navigation:

```ts
channel.emit('setCurrentStory', { storyId, viewMode: TEST_RUNNER_VIEW_MODE });
```

But `setupPage` in `setup-page.ts` never replaces `{{viewMode}}` before injecting the script. All other placeholders (`{{storybookUrl}}`, `{{failOnConsole}}`, `{{renderedEvent}}`, etc.) are substituted — `{{viewMode}}` was simply missing from the chain.

## Effect

The browser receives the literal string `"{{viewMode}}"` as the `viewMode` argument to `setCurrentStory`. Storybook 8+ syncs this into the iframe URL as `?viewMode=%7B%7BviewMode%7D%7D`. When an unknown `viewMode` is set, Storybook can trigger a hard iframe navigation mid-test, which destroys Playwright's execution context and produces:

```
page.evaluate: Execution context was destroyed, most likely because of a navigation
```

This failure is intermittent (depends on timing of the navigation vs. the script evaluation) and has no obvious stack trace pointing at the root cause, making it appear as general test flakiness.

Diagnostic evidence: every `setCurrentStory` NAV event carried `viewMode=%7B%7BviewMode%7D%7D` literally; the runner's `catch → resetPage()` retry branch fired 2 seconds later — matching the exact retry signature in `@playwright/test`'s jestPlaywright integration.

## Fix

Add `.replaceAll('{{viewMode}}', viewMode)` to the substitution chain. `viewMode` is already computed two lines above from `process.env.VIEW_MODE ?? 'story'`.

```diff
-    .replaceAll('{{debugPrintLimit}}', debugPrintLimit.toString());
+    .replaceAll('{{debugPrintLimit}}', debugPrintLimit.toString())
+    .replaceAll('{{viewMode}}', viewMode);
```

## Testing

Verified by running the test-runner against a Storybook 8 instance with `VIEW_MODE=story` (default). The `setCurrentStory` events now carry `viewMode: "story"` and the intermittent navigation-destroy failures no longer occur.
