### PR TITLE
Speed up playwright coverage collection by serializing the coverage object in-page

### DIFF
--- a/src/jest-playwright-preset/PlaywrightEnvironment.ts
+++ b/src/jest-playwright-preset/PlaywrightEnvironment.ts
@@ -180,13 +180,13 @@ export const getPlaywrightEnv = (): unknown => {
     }
 
     async _setCollectCoverage(context: BrowserContext) {
-      await context.exposeFunction('reportCodeCoverage', (coverage: unknown) => {
+      await context.exposeFunction('reportCodeCoverage', (coverage: string) => {
         if (coverage) saveCoverageToFile(coverage);
       });
       await context.addInitScript(() =>
         window.addEventListener('beforeunload', () => {
           // @ts-ignore
-          reportCodeCoverage(window.__coverage__);
+          reportCodeCoverage(JSON.stringify(window.__coverage__));
         })
       );
     }

--- a/src/jest-playwright-preset/coverage.ts
+++ b/src/jest-playwright-preset/coverage.ts
@@ -25,8 +25,8 @@ export const setupCoverage = async (): Promise<void> => {
   await fsAsync.mkdir(COV_MERGE_DIR);
 };
 
-export const saveCoverageToFile = async (coverage: unknown): Promise<void> => {
-  await fsAsync.writeFile(path.join(COV_MERGE_DIR, `${uuid.v4()}.json`), JSON.stringify(coverage));
+export const saveCoverageToFile = async (coverage: string): Promise<void> => {
+  await fsAsync.writeFile(path.join(COV_MERGE_DIR, `${uuid.v4()}.json`), coverage);
 };
 
 export const saveCoverageOnPage = async (page: Page, collectCoverage = false): Promise<void> => {
@@ -36,7 +36,7 @@ export const saveCoverageOnPage = async (page: Page, collectCoverage = false): P
     );
     return;
   }
-  const coverage = await page.evaluate(`window.__coverage__`);
+  const coverage = await page.evaluate(() => JSON.stringify(window.__coverage__));
   if (coverage) {
     await saveCoverageToFile(coverage);
   }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -8,4 +8,8 @@ declare global {
   var __getContext: (storyId: string) => StoryContext;
   var __sbSetupPage: typeof setupPage;
   var __sbCollectCoverage: boolean;
+
+  interface Window {
+    __coverage__?: unknown;
+  }
 }


### PR DESCRIPTION
## What I did

This PR serializes `window.__coverage__` in page before passing it to playwright. That saves Playwright from serializing the coverage object to hand it back from the browser to Node. page.evaluate has to copy it's return value out of the browser process into the test-runner process: for a big object that means Playwright deep-walks the whole thing to package it up, then rebuilds it on the other side. Returning a string means it just copies one string across.

On the relatively heavy UI project with 211 stories that gave a good performance boost reducing run with coverage from ~4mins to ~1min.

## Checklist for Contributors

#### Manual testing

I think tests cover for it, but I compared nyc reports before and after on my repo and after running `yarn test-storybook:ci` before and after changes

### Documentation

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to indicate which documentation has been updated. -->

- [ ] Add or update documentation reflecting your changes in this repository
- [ ] Request documentation updates in the [test-runner docs website](https://storybook.js.org/docs/writing-tests/test-runner)

<!-- Regarding requesting documentation updates, please notify the maintainers of this repo in this PR. -->

## Checklist for Maintainers

- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

  - `skip-release`: Skip any releases, e.g., documentation only changes, CI config etc.
  - `patch`: Upgrade patch version (e.g. 0.0.x)
  - `minor`: Upgrade patch version (e.g. 0.x.0)
  - `major`: Upgrade patch version (e.g. x.0.0)

   </details>
